### PR TITLE
Increase land value on dice throw

### DIFF
--- a/libs/data-access-game/src/lib/+state/dice/dice.effects.spec.ts
+++ b/libs/data-access-game/src/lib/+state/dice/dice.effects.spec.ts
@@ -4,15 +4,21 @@ import { Action } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
 import { DataPersistence, NxModule } from '@nrwl/angular';
 import { hot } from '@nrwl/angular/testing';
+import { DiceId, EventValue } from '@taormina/shared-models';
 import { Observable } from 'rxjs';
 
+import * as DomainsCardsActions from '../domains-cards/domains-cards.actions';
 import * as DiceActions from './dice.actions';
 import { DiceEffects } from './dice.effects';
 
 jest.mock('./dice.models', () => {
   return {
     __esModule: true,
-    createRandomDice: jest.fn(() => []),
+    createRandomDice: jest.fn(() => {
+      const resource = { id: DiceId.Resource, value: 1 };
+      const event = { id: DiceId.Event, value: EventValue.Event };
+      return { resource, event };
+    }),
   };
 });
 
@@ -39,7 +45,12 @@ describe('DiceEffects', () => {
       actions = hot('-a-|', { a: DiceActions.initDiceNewGame() });
 
       const expected = hot('-a-|', {
-        a: DiceActions.setDiceInitialized({ dice: [] }),
+        a: DiceActions.setDiceInitialized({
+          dice: [
+            { id: DiceId.Resource, value: 1 },
+            { id: DiceId.Event, value: EventValue.Event },
+          ],
+        }),
       });
 
       expect(effects.initNewGame$).toBeObservable(expected);
@@ -55,6 +66,24 @@ describe('DiceEffects', () => {
       });
 
       expect(effects.initSavedGame$).toBeObservable(expected);
+    });
+  });
+
+  describe('throw$', () => {
+    it('should work', () => {
+      actions = hot('-a', { a: DiceActions.throwDice() });
+
+      const expected = hot('-(ab)', {
+        a: DiceActions.upsertDice({
+          dice: [
+            { id: DiceId.Resource, value: 1 },
+            { id: DiceId.Event, value: EventValue.Event },
+          ],
+        }),
+        b: DomainsCardsActions.increaseLandValueForDie({ die: 1 }),
+      });
+
+      expect(effects.throw$).toBeObservable(expected);
     });
   });
 });

--- a/libs/data-access-game/src/lib/+state/dice/dice.effects.ts
+++ b/libs/data-access-game/src/lib/+state/dice/dice.effects.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
-import { createEffect, Actions, ofType } from '@ngrx/effects';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { fetch } from '@nrwl/angular';
-import { map } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 
+import * as DomainsCardsActions from '../domains-cards/domains-cards.actions';
 import * as DiceActions from './dice.actions';
 import { createRandomDice } from './dice.models';
 
@@ -13,7 +14,7 @@ export class DiceEffects {
       ofType(DiceActions.initDiceNewGame),
       map(() => {
         const dice = createRandomDice();
-        return DiceActions.setDiceInitialized({ dice });
+        return DiceActions.setDiceInitialized({ dice: Object.values(dice) });
       })
     )
   );
@@ -38,10 +39,13 @@ export class DiceEffects {
   throw$ = createEffect(() =>
     this.actions$.pipe(
       ofType(DiceActions.throwDice),
-      map(() => {
-        const dice = createRandomDice();
-        return DiceActions.upsertDice({ dice });
-      })
+      map(() => createRandomDice()),
+      switchMap((dice) => [
+        DiceActions.upsertDice({ dice: Object.values(dice) }),
+        DomainsCardsActions.increaseLandValueForDie({
+          die: dice.resource.value,
+        }),
+      ])
     )
   );
 

--- a/libs/data-access-game/src/lib/+state/dice/dice.models.ts
+++ b/libs/data-access-game/src/lib/+state/dice/dice.models.ts
@@ -59,5 +59,5 @@ function eventFromValue(value: DiceValue): EventValue {
 export function createRandomDice() {
   const resource = createResourceDiceEntity(randomDiceValue());
   const event = createEventDiceEntity(eventFromValue(randomDiceValue()));
-  return [resource, event];
+  return { resource, event };
 }

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.actions.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.actions.ts
@@ -1,4 +1,7 @@
+import { UpdateStr } from '@ngrx/entity/src/models';
 import { createAction, props } from '@ngrx/store';
+import { ResourceValue } from '@taormina/shared-models';
+
 import { DomainsCardsEntity } from './domains-cards.models';
 
 export const initDomainsCardsNewGame = createAction(
@@ -22,4 +25,14 @@ export const loadDomainsCardsFailure = createAction(
 export const setDomainsCardsInitialized = createAction(
   '[DomainsCards] Set DomainsCards On Init',
   props<{ domainsCards: DomainsCardsEntity[] }>()
+);
+
+export const increaseLandValueForDie = createAction(
+  '[DomainsCards] Increase Land Value For Die',
+  props<{ die: ResourceValue }>()
+);
+
+export const updateDomainsCards = createAction(
+  '[DomainsCards] Update DomainsCards',
+  props<{ updates: UpdateStr<DomainsCardsEntity>[] }>()
 );

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.spec.ts
@@ -4,10 +4,16 @@ import { Action } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
 import { DataPersistence, NxModule } from '@nrwl/angular';
 import { hot } from '@nrwl/angular/testing';
+import { ID_DOMAIN_BLUE, ID_DOMAIN_RED } from '@taormina/shared-constants';
+import {
+  AGGLOMERATION_CARD_INTERFACE_NAME,
+  LAND_CARD_INTERFACE_NAME,
+} from '@taormina/shared-models';
 import { Observable } from 'rxjs';
 
 import * as DomainsCardsActions from './domains-cards.actions';
 import { DomainsCardsEffects } from './domains-cards.effects';
+import * as DomainsCardsSelectors from './domains-cards.selectors';
 
 jest.mock('./domains-cards.models', () => {
   return {
@@ -27,7 +33,41 @@ describe('DomainsCardsEffects', () => {
         DomainsCardsEffects,
         DataPersistence,
         provideMockActions(() => actions),
-        provideMockStore(),
+        provideMockStore({
+          selectors: [
+            {
+              selector: DomainsCardsSelectors.getLandCardsPivotsForDie,
+              value: [
+                {
+                  id: 'AAA',
+                  domainId: ID_DOMAIN_RED,
+                  cardType: AGGLOMERATION_CARD_INTERFACE_NAME,
+                  cardId: 'ROAD_1',
+                },
+                {
+                  id: 'BBB',
+                  domainId: ID_DOMAIN_BLUE,
+                  cardType: LAND_CARD_INTERFACE_NAME,
+                  cardId: 'LAND_1',
+                  value: 0,
+                },
+                {
+                  id: 'CCC',
+                  domainId: ID_DOMAIN_RED,
+                  cardType: LAND_CARD_INTERFACE_NAME,
+                  cardId: 'LAND_2',
+                  value: 3,
+                },
+                {
+                  id: 'DDD',
+                  domainId: ID_DOMAIN_BLUE,
+                  cardType: LAND_CARD_INTERFACE_NAME,
+                  cardId: 'LAND_3',
+                },
+              ],
+            },
+          ],
+        }),
       ],
     });
 
@@ -61,6 +101,27 @@ describe('DomainsCardsEffects', () => {
       });
 
       expect(effects.initSavedGame$).toBeObservable(expected);
+    });
+  });
+
+  describe('increaseResourceValue$', () => {
+    it('should work', () => {
+      actions = hot('-a-|', {
+        a: DomainsCardsActions.increaseLandValueForDie({ die: 1 }),
+      });
+
+      const expected = hot('-a-|', {
+        a: DomainsCardsActions.updateDomainsCards({
+          updates: [
+            {
+              id: 'BBB',
+              changes: { value: 1 },
+            },
+          ],
+        }),
+      });
+
+      expect(effects.increaseResourceValue$).toBeObservable(expected);
     });
   });
 });

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { select, Store } from '@ngrx/store';
 import { fetch } from '@nrwl/angular';
-import { map } from 'rxjs/operators';
+import { LandValue } from '@taormina/shared-models';
+import { concatMap, map, take } from 'rxjs/operators';
 
 import * as DomainsCardsActions from './domains-cards.actions';
 import { createInitialDomainsCards } from './domains-cards.models';
+import * as DomainsCardsFeature from './domains-cards.reducer';
+import * as DomainsCardsSelectors from './domains-cards.selectors';
 
 @Injectable()
 export class DomainsCardsEffects {
@@ -38,5 +42,34 @@ export class DomainsCardsEffects {
     )
   );
 
-  constructor(private actions$: Actions) {}
+  increaseResourceValue$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(DomainsCardsActions.increaseLandValueForDie),
+      concatMap((action) =>
+        this.domainsCardsStore.pipe(
+          select(DomainsCardsSelectors.getLandCardsPivotsForDie, {
+            die: action.die,
+          }),
+          take(1)
+        )
+      ),
+      map((pivots) => {
+        const updates = pivots
+          // Don't update land cards already at max value
+          .filter((pivot) => (pivot.value as LandValue) < 3)
+          .map((pivot) => {
+            return {
+              id: pivot.id,
+              changes: { value: ((pivot.value as LandValue) + 1) as LandValue },
+            };
+          });
+        return DomainsCardsActions.updateDomainsCards({ updates });
+      })
+    )
+  );
+
+  constructor(
+    private actions$: Actions,
+    private domainsCardsStore: Store<DomainsCardsFeature.DomainsCardsPartialState>
+  ) {}
 }

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.reducer.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.reducer.spec.ts
@@ -12,8 +12,42 @@ import {
 } from './domains-cards.reducer';
 
 describe('DomainsCards Reducer', () => {
-  describe('valid DomainsCards actions', () => {
-    it('loadDomainsCardsSuccess should set the list of known DomainsCards', () => {
+  describe('unknown action', () => {
+    it('should return the previous state', () => {
+      const action = {} as Action;
+
+      const result = domainsCardsReducer(initialDomainsCardsState, action);
+
+      expect(result).toBe(initialDomainsCardsState);
+    });
+  });
+
+  describe('loadDomainsCardsSuccess', () => {
+    it('should set the list of known DomainsCards and loaded', () => {
+      const newState: DomainsCardsState = {
+        ids: ['PRODUCT-AAA', 'PRODUCT-zzz'],
+        entities: {
+          'PRODUCT-AAA': {
+            id: 'PRODUCT-AAA',
+            domainId: 'A',
+            cardType: DEVELOPMENT_CARD_INTERFACE_NAME,
+            cardId: 'A',
+            col: 0,
+            row: 0,
+          },
+          'PRODUCT-zzz': {
+            id: 'PRODUCT-zzz',
+            domainId: 'z',
+            cardType: AGGLOMERATION_CARD_INTERFACE_NAME,
+            cardId: 'z',
+            col: 0,
+            row: 0,
+          },
+        },
+        initialized: false,
+        loaded: true,
+      };
+
       const domainsCards = [
         createDomainsCardsEntity(
           'PRODUCT-AAA',
@@ -36,23 +70,86 @@ describe('DomainsCards Reducer', () => {
         domainsCards,
       });
 
-      const result: DomainsCardsState = domainsCardsReducer(
+      const state: DomainsCardsState = domainsCardsReducer(
         initialDomainsCardsState,
         action
       );
 
-      expect(result.loaded).toBe(true);
-      expect(result.ids.length).toBe(2);
+      expect(state).toEqual(newState);
     });
   });
 
-  describe('unknown action', () => {
-    it('should return the previous state', () => {
-      const action = {} as Action;
+  describe('updateDomainsCards', () => {
+    it('should update the right DomainsCards in the list', () => {
+      const newState: DomainsCardsState = {
+        ids: ['PRODUCT-AAA', 'PRODUCT-zzz'],
+        entities: {
+          'PRODUCT-AAA': {
+            id: 'PRODUCT-AAA',
+            domainId: 'A',
+            cardType: AGGLOMERATION_CARD_INTERFACE_NAME,
+            cardId: 'A',
+            col: 0,
+            row: 0,
+            value: 1,
+          },
+          'PRODUCT-zzz': {
+            id: 'PRODUCT-zzz',
+            domainId: 'z',
+            cardType: DEVELOPMENT_CARD_INTERFACE_NAME,
+            cardId: 'z',
+            col: 0,
+            row: 0,
+            value: 0,
+          },
+        },
+        initialized: true,
+        loaded: false,
+      };
 
-      const result = domainsCardsReducer(initialDomainsCardsState, action);
+      const initialState: DomainsCardsState = {
+        ids: ['PRODUCT-AAA', 'PRODUCT-zzz'],
+        entities: {
+          'PRODUCT-AAA': {
+            id: 'PRODUCT-AAA',
+            domainId: 'A',
+            cardType: AGGLOMERATION_CARD_INTERFACE_NAME,
+            cardId: 'A',
+            col: 0,
+            row: 0,
+            value: 0,
+          },
+          'PRODUCT-zzz': {
+            id: 'PRODUCT-zzz',
+            domainId: 'z',
+            cardType: DEVELOPMENT_CARD_INTERFACE_NAME,
+            cardId: 'z',
+            col: 0,
+            row: 0,
+            value: 0,
+          },
+        },
+        initialized: true,
+        loaded: false,
+      };
 
-      expect(result).toBe(initialDomainsCardsState);
+      const action = DomainsCardsActions.updateDomainsCards({
+        updates: [
+          {
+            id: 'PRODUCT-AAA',
+            changes: {
+              value: 1,
+            },
+          },
+        ],
+      });
+
+      const state: DomainsCardsState = domainsCardsReducer(
+        initialState,
+        action
+      );
+
+      expect(state).toEqual(newState);
     });
   });
 });

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.reducer.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.reducer.ts
@@ -49,5 +49,8 @@ export const domainsCardsReducer = createReducer(
     DomainsCardsActions.setDomainsCardsInitialized,
     (state, { domainsCards }) =>
       domainsCardsAdapter.setAll(domainsCards, { ...state, initialized: true })
+  ),
+  on(DomainsCardsActions.updateDomainsCards, (state, { updates }) =>
+    domainsCardsAdapter.updateMany(updates, state)
   )
 );

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
@@ -1,7 +1,9 @@
+import { ID_DOMAIN_BLUE, ID_DOMAIN_RED } from '@taormina/shared-constants';
 import {
   AGGLOMERATION_CARD_INTERFACE_NAME,
-  DEVELOPMENT_CARD_INTERFACE_NAME,
+  LAND_CARD_INTERFACE_NAME,
 } from '@taormina/shared-models';
+
 import {
   createDomainsCardsEntity,
   DomainsCardsEntity,
@@ -28,25 +30,25 @@ describe('DomainsCards Selectors', () => {
         [
           createDomainsCardsEntity(
             'PRODUCT-AAA',
-            'A',
+            ID_DOMAIN_RED,
             AGGLOMERATION_CARD_INTERFACE_NAME,
-            'A',
+            'ROAD_1',
             0,
             0
           ),
           createDomainsCardsEntity(
             'PRODUCT-BBB',
-            'B',
-            DEVELOPMENT_CARD_INTERFACE_NAME,
-            'B',
+            ID_DOMAIN_BLUE,
+            LAND_CARD_INTERFACE_NAME,
+            'LAND_1',
             0,
             0
           ),
           createDomainsCardsEntity(
             'PRODUCT-CCC',
-            'C',
-            AGGLOMERATION_CARD_INTERFACE_NAME,
-            'C',
+            ID_DOMAIN_BLUE,
+            LAND_CARD_INTERFACE_NAME,
+            'LAND_3',
             0,
             0
           ),
@@ -87,6 +89,15 @@ describe('DomainsCards Selectors', () => {
       const result = DomainsCardsSelectors.getDomainsCardsError(state);
 
       expect(result).toBe(ERROR_MSG);
+    });
+
+    it('getLandCardsPivotsForDie({ die }) should return the pivot for the land card with the right die', () => {
+      const result = DomainsCardsSelectors.getLandCardsPivotsForDie(state, {
+        die: 1,
+      });
+      const selId = getDomainsCardsId(result[0]);
+
+      expect(selId).toBe('PRODUCT-BBB');
     });
   });
 });

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
@@ -1,4 +1,10 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { landCards } from '@taormina/shared-constants';
+import {
+  LAND_CARD_INTERFACE_NAME,
+  ResourceValue,
+} from '@taormina/shared-models';
+import { DomainsCardsEntity } from './domains-cards.models';
 import {
   DOMAINS_CARDS_FEATURE_KEY,
   DomainsCardsState,
@@ -46,4 +52,16 @@ export const getDomainsCardsSelected = createSelector(
     if (selectedId === undefined) return undefined;
     return entities[selectedId];
   }
+);
+
+export const getLandCardsPivotsForDie = createSelector(
+  getAllDomainsCards,
+  (entities: DomainsCardsEntity[], props: { die: ResourceValue }) =>
+    entities.filter((pivot) => {
+      if (pivot.cardType === LAND_CARD_INTERFACE_NAME) {
+        const land = landCards.get(pivot.cardId);
+        if (land && land.die === props.die) return true;
+      }
+      return false;
+    })
 );

--- a/libs/data-access-game/src/lib/+state/hands-cards/hands-cards.reducer.spec.ts
+++ b/libs/data-access-game/src/lib/+state/hands-cards/hands-cards.reducer.spec.ts
@@ -24,6 +24,26 @@ describe('HandsCards Reducer', () => {
 
   describe('loadHandsCardsSuccess', () => {
     it('should set the list of known HandsCards and loaded', () => {
+      const newState: HandsCardsState = {
+        ids: ['PRODUCT-AAA', 'PRODUCT-zzz'],
+        entities: {
+          'PRODUCT-AAA': {
+            id: 'PRODUCT-AAA',
+            handId: 'A',
+            cardType: ACTION_CARD_INTERFACE_NAME,
+            cardId: 'A',
+          },
+          'PRODUCT-zzz': {
+            id: 'PRODUCT-zzz',
+            handId: 'z',
+            cardType: DEVELOPMENT_CARD_INTERFACE_NAME,
+            cardId: 'z',
+          },
+        },
+        initialized: false,
+        loaded: true,
+      };
+
       const handsCards = [
         createHandsCardsEntity(
           'PRODUCT-AAA',
@@ -40,13 +60,12 @@ describe('HandsCards Reducer', () => {
       ];
       const action = HandsCardsActions.loadHandsCardsSuccess({ handsCards });
 
-      const result: HandsCardsState = handsCardsReducer(
+      const state: HandsCardsState = handsCardsReducer(
         initialHandsCardsState,
         action
       );
 
-      expect(result.loaded).toBe(true);
-      expect(result.ids.length).toBe(2);
+      expect(state).toEqual(newState);
     });
   });
 


### PR DESCRIPTION
On dice throw, dispatch domains cards increaseLandValueForDie.
On increaseLandValueForDie, update domains cards with value + 1, when land cards of the right die.