### PR TITLE
TAOR-31: Handle neighboring rows with towns

### DIFF
--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
@@ -737,7 +737,7 @@ describe('DomainsCards Selectors', () => {
               DEVELOPMENT_CARD_INTERFACE_NAME,
               'BUILDING_6',
               -1,
-              1
+              2
             ),
             createDomainsCardsEntity(
               'eeee',

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
@@ -256,5 +256,7 @@ const getCardSideNeighbors = (
     (domainCard) =>
       domainCard.domainId === pivot.domainId &&
       (domainCard.col === pivot.col - 1 || domainCard.col === pivot.col + 1) &&
-      domainCard.row === pivot.row
+      (pivot.row < 0
+        ? domainCard.row === -1 || domainCard.row === -2
+        : domainCard.row === 1 || domainCard.row === 2)
   );

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
@@ -239,7 +239,7 @@ const isNextToAWarehouse = (
   pivot: DomainsCardsEntity,
   entities: DomainsCardsEntity[]
 ): boolean => {
-  const neighbors = getDevelopmentCardNeighbors(pivot, entities);
+  const neighbors = getCardSideNeighbors(pivot, entities);
   return (
     neighbors.find(
       (neighbor) =>
@@ -248,7 +248,7 @@ const isNextToAWarehouse = (
   );
 };
 
-const getDevelopmentCardNeighbors = (
+const getCardSideNeighbors = (
   pivot: DomainsCardsEntity,
   entities: DomainsCardsEntity[]
 ): DomainsCardsEntity[] =>


### PR DESCRIPTION
### Description
Change method name to reflect difference between side and diagonal neighbors.
Extend side neighbors selector to second row.

https://lhbruneton.atlassian.net/browse/TAOR-31

### Checklist
- [ ] Created tests with given/when/then blocks
- [x] Created tests for the nominal use case
- [ ] Created tests for errors
- [x] Build project without errors
