### PR TITLE
TAOR-29: Add specific rules when buying a town

### DIFF
--- a/apps/taormina-duel/src/app/app.component.html
+++ b/apps/taormina-duel/src/app/app.component.html
@@ -231,6 +231,9 @@
           "
         >
           {{ agglomeration.type }}
+          <button type="button" (click)="selectDomainCard(pivot.id)">
+            Select
+          </button>
         </div>
       </div>
       <div *ngSwitchCase="LAND_CARD_INTERFACE_NAME">
@@ -313,6 +316,9 @@
           "
         >
           {{ agglomeration.type }}
+          <button type="button" (click)="selectDomainCard(pivot.id)">
+            Select
+          </button>
         </div>
       </div>
       <div *ngSwitchCase="LAND_CARD_INTERFACE_NAME">

--- a/libs/feature-engine/src/lib/game-rules.service.spec.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.spec.ts
@@ -13,6 +13,7 @@ import {
   ID_DOMAIN_RED,
   ID_FACE_UP_HAMLET,
   ID_FACE_UP_ROAD,
+  ID_FACE_UP_TOWN,
   ID_HAND_RED,
 } from '@taormina/shared-constants';
 import {
@@ -354,6 +355,81 @@ describe('GameRulesService', () => {
         expect(
           domainsCardsFacadeMock.createAvailableDomainCard
         ).toHaveBeenNthCalledWith(3, ID_DOMAIN_RED, AVAILABLE_LAND_SLOT, -4, 1);
+        expect(domainsCardsFacadeMock.unselectDomainCard).toHaveBeenCalledTimes(
+          1
+        );
+      });
+    });
+
+    describe('OK town', () => {
+      const domainsCardsFacadeMock = {
+        selectedDomainsCards$: of({
+          id: 'aaaa',
+          domainId: ID_DOMAIN_RED,
+          cartType: AGGLOMERATION_CARD_INTERFACE_NAME,
+          cardId: 'aaaa',
+          col: -1,
+          row: 0,
+        }),
+        createAvailableDomainCard: jest.fn(),
+        putCardInSlot: jest.fn(),
+        unselectDomainCard: jest.fn(),
+        useLockedResources: jest.fn(),
+      };
+      const faceUpPilesCardsFacadeMock = {
+        selectedFaceUpPilesCards$: of({
+          id: 'aaaa',
+          pileId: ID_FACE_UP_TOWN,
+          cardId: 'TOWN_1',
+        }),
+        removeFaceUpPileCard: jest.fn(),
+      };
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          providers: [
+            { provide: DomainsCardsFacade, useValue: domainsCardsFacadeMock },
+            {
+              provide: FaceUpPilesCardsFacade,
+              useValue: faceUpPilesCardsFacadeMock,
+            },
+          ],
+        });
+        service = TestBed.inject(GameRulesService);
+      });
+
+      it('should call useLockedResources, removeFaceUpPileCard, putCardInSlot, createAvailableDomainCard x2, unselectDomainCard', () => {
+        service.useResourcesToPutFaceUpPileCardInSlot();
+
+        expect(domainsCardsFacadeMock.useLockedResources).toHaveBeenCalledTimes(
+          1
+        );
+        expect(
+          faceUpPilesCardsFacadeMock.removeFaceUpPileCard
+        ).toHaveBeenCalledWith('aaaa');
+        expect(domainsCardsFacadeMock.putCardInSlot).toHaveBeenCalledWith(
+          'aaaa',
+          AGGLOMERATION_CARD_INTERFACE_NAME,
+          'TOWN_1'
+        );
+        expect(
+          domainsCardsFacadeMock.createAvailableDomainCard
+        ).toHaveBeenNthCalledWith(
+          1,
+          ID_DOMAIN_RED,
+          AVAILABLE_DEVELOPMENT_SLOT,
+          -1,
+          -2
+        );
+        expect(
+          domainsCardsFacadeMock.createAvailableDomainCard
+        ).toHaveBeenNthCalledWith(
+          2,
+          ID_DOMAIN_RED,
+          AVAILABLE_DEVELOPMENT_SLOT,
+          -1,
+          2
+        );
         expect(domainsCardsFacadeMock.unselectDomainCard).toHaveBeenCalledTimes(
           1
         );

--- a/libs/feature-engine/src/lib/game-rules.service.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.ts
@@ -8,10 +8,11 @@ import {
   LandsPileCardsFacade,
   StockPilesCardsFacade,
 } from '@taormina/data-access-game';
-import { ID_FACE_UP_HAMLET } from '@taormina/shared-constants';
+import { ID_FACE_UP_HAMLET, ID_FACE_UP_TOWN } from '@taormina/shared-constants';
 import {
   AGGLOMERATION_CARD_INTERFACE_NAME,
   AVAILABLE_AGGLOMERATION_SLOT,
+  AVAILABLE_DEVELOPMENT_SLOT,
   AVAILABLE_LAND_SLOT,
   DEVELOPMENT_CARD_INTERFACE_NAME,
   LAND_CARD_INTERFACE_NAME,
@@ -97,27 +98,42 @@ export class GameRulesService {
             faceUpPileCard.cardId
           );
 
-          const availableCol =
-            domainCard.col < 0 ? domainCard.col - 1 : domainCard.col + 1;
-          this.domainsCards.createAvailableDomainCard(
-            domainCard.domainId,
-            AVAILABLE_AGGLOMERATION_SLOT,
-            availableCol,
-            0
-          );
-          if (faceUpPileCard.pileId === ID_FACE_UP_HAMLET) {
+          if (faceUpPileCard.pileId === ID_FACE_UP_TOWN) {
             this.domainsCards.createAvailableDomainCard(
               domainCard.domainId,
-              AVAILABLE_LAND_SLOT,
-              availableCol,
-              -1
+              AVAILABLE_DEVELOPMENT_SLOT,
+              domainCard.col,
+              -2
             );
             this.domainsCards.createAvailableDomainCard(
               domainCard.domainId,
-              AVAILABLE_LAND_SLOT,
-              availableCol,
-              1
+              AVAILABLE_DEVELOPMENT_SLOT,
+              domainCard.col,
+              2
             );
+          } else {
+            const availableCol =
+              domainCard.col < 0 ? domainCard.col - 1 : domainCard.col + 1;
+            this.domainsCards.createAvailableDomainCard(
+              domainCard.domainId,
+              AVAILABLE_AGGLOMERATION_SLOT,
+              availableCol,
+              0
+            );
+            if (faceUpPileCard.pileId === ID_FACE_UP_HAMLET) {
+              this.domainsCards.createAvailableDomainCard(
+                domainCard.domainId,
+                AVAILABLE_LAND_SLOT,
+                availableCol,
+                -1
+              );
+              this.domainsCards.createAvailableDomainCard(
+                domainCard.domainId,
+                AVAILABLE_LAND_SLOT,
+                availableCol,
+                1
+              );
+            }
           }
 
           this.domainsCards.unselectDomainCard();


### PR DESCRIPTION
### Description
Allow selecting hamlet cards, and all unavailable agglomeration cards.
Add rules specific to town, to add -2/+2 available development cards, instead of neighboring available agglomeration/land cards.

https://lhbruneton.atlassian.net/browse/TAOR-29

### Checklist
- [ ] Created tests with given/when/then blocks
- [x] Created tests for the nominal use case
- [ ] Created tests for errors
- [x] Build project without errors

### Screenshot

![image](https://user-images.githubusercontent.com/39385253/114605006-e7ee1000-9c99-11eb-8127-dced73b7d137.png)

