### PR TITLE
chore: configure CI/CD workflows

### DIFF
--- a/.github/workflows/main_cd.yml
+++ b/.github/workflows/main_cd.yml
@@ -1,18 +1,28 @@
-name: CD
+name: CI
+
 on:
   push:
     branches:
       - master
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
-  build:
-
+  build-and-deploy:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Build and Deploy
-      uses: AhsanAyaz/angular-deploy-gh-pages-actions@v1.3.1
-      with:
-        github_access_token: ${{ secrets.GITHUB_TOKEN }}
-        base_href: /taormina/
-        angular_dist_build_folder: docs
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install
+        run: npm install
+
+      - name: Build
+        run: npm run build:gh-pages
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: docs

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -1,36 +1,25 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
-
+    branches: [master]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  lint_and_test:
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
+      - name: Install
+        run: npm install
 
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test

--- a/angular.json
+++ b/angular.json
@@ -10,7 +10,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "docs",
+            "outputPath": "dist/apps/taormina-duel",
             "index": "apps/taormina-duel/src/index.html",
             "main": "apps/taormina-duel/src/main.ts",
             "polyfills": "apps/taormina-duel/src/polyfills.ts",
@@ -267,6 +267,7 @@
     }
   },
   "cli": {
+    "analytics": false,
     "defaultCollection": "@nrwl/angular"
   },
   "schematics": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "nx": "nx",
     "start": "ng serve",
     "build": "ng build",
+    "build:gh-pages": "ng build --prod --output-path docs --base-href /taormina/",
     "test": "ng test",
     "lint": "nx workspace-lint && ng lint",
     "lint:styles": "stylelint \"apps/**/*.css\"",


### PR DESCRIPTION
Simplified CI workflow to only run lint and test as a normal angular project.
Added CD workflow to deploy to gh-pages.
Reverted non-working previous fixes on workflows and project configuration.