### PR TITLE
TAOR-38: Steal unprotected resources on thieves event only

### DIFF
--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.actions.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.actions.ts
@@ -100,6 +100,6 @@ export const createDomainCard = createAction(
   }>()
 );
 
-export const stealUnprotectedGoldAndWool = createAction(
-  '[DomainsCards] Steal Unprotected Gold And Wool'
+export const countAndStealUnprotectedGoldAndWool = createAction(
+  '[DomainsCards] Count And Steal Unprotected Gold And Wool'
 );

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.spec.ts
@@ -644,7 +644,7 @@ describe('DomainsCardsEffects', () => {
     });
   });
 
-  describe('stealResources$', () => {
+  describe('countStealResources$', () => {
     describe('not enough resources', () => {
       beforeEach(() => {
         injector = Injector.create({
@@ -687,14 +687,14 @@ describe('DomainsCardsEffects', () => {
 
       it('should dispatch updateDomainsCards with empty array', () => {
         actions = hot('-a-|', {
-          a: DomainsCardsActions.stealUnprotectedGoldAndWool(),
+          a: DomainsCardsActions.countAndStealUnprotectedGoldAndWool(),
         });
 
         const expected = hot('-a-|', {
           a: DomainsCardsActions.updateDomainsCards({ updates: [] }),
         });
 
-        expect(effects.stealResources$).toBeObservable(expected);
+        expect(effects.countStealResources$).toBeObservable(expected);
       });
     });
 
@@ -740,7 +740,7 @@ describe('DomainsCardsEffects', () => {
 
       it('should dispatch updateDomainsCards with array of changes', () => {
         actions = hot('-a-|', {
-          a: DomainsCardsActions.stealUnprotectedGoldAndWool(),
+          a: DomainsCardsActions.countAndStealUnprotectedGoldAndWool(),
         });
 
         const expected = hot('-a-|', {
@@ -767,7 +767,7 @@ describe('DomainsCardsEffects', () => {
           }),
         });
 
-        expect(effects.stealResources$).toBeObservable(expected);
+        expect(effects.countStealResources$).toBeObservable(expected);
       });
     });
   });

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.ts
@@ -237,9 +237,9 @@ export class DomainsCardsEffects {
     )
   );
 
-  stealResources$ = createEffect(() =>
+  countStealResources$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(DomainsCardsActions.stealUnprotectedGoldAndWool),
+      ofType(DomainsCardsActions.countAndStealUnprotectedGoldAndWool),
       withLatestFrom(
         this.domainsCardsStore.select(
           DomainsCardsSelectors.getDomainResourceCountSeenByThieves,

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.facade.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.facade.ts
@@ -96,8 +96,10 @@ export class DomainsCardsFacade {
     );
   }
 
-  stealUnprotectedGoldAndWool(): void {
-    this.store.dispatch(DomainsCardsActions.stealUnprotectedGoldAndWool());
+  countAndStealUnprotectedGoldAndWool(): void {
+    this.store.dispatch(
+      DomainsCardsActions.countAndStealUnprotectedGoldAndWool()
+    );
   }
 
   getDomainMinCol(domainId: string): Observable<number> {


### PR DESCRIPTION
### Description
Rename steal action to count and steal to better describe the logic.
Subscribe to the thieves event, to only dispatch the count and steal action then.

https://lhbruneton.atlassian.net/browse/TAOR-38

### Checklist
- [x] Created tests with given/when/then blocks
- [x] Created tests for the nominal use case
- [ ] Created tests for errors
- [x] Build project without errors
