### PR TITLE
TAOR-14: Take into account neighboring production buildings

### DIFF
--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.spec.ts
@@ -6,13 +6,14 @@ import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { DataPersistence, NxModule } from '@nrwl/angular';
 import { hot } from '@nrwl/angular/testing';
 import {
+  ID_CLAY_PIT_RED,
   ID_DOMAIN_BLUE,
   ID_DOMAIN_RED,
+  ID_FOREST_BLUE,
   ID_GOLD_MINE_RED,
   ID_PASTURE_BLUE,
 } from '@taormina/shared-constants';
 import {
-  AGGLOMERATION_CARD_INTERFACE_NAME,
   AVAILABLE_AGGLOMERATION_SLOT,
   LAND_CARD_INTERFACE_NAME,
 } from '@taormina/shared-models';
@@ -90,33 +91,49 @@ describe('DomainsCardsEffects', () => {
           provideMockStore({
             selectors: [
               {
-                selector: DomainsCardsSelectors.getLandCardsPivotsForDie,
+                selector:
+                  DomainsCardsSelectors.getLandCardsPivotsIncreaseOneProduction,
                 value: [
                   {
                     id: 'AAA',
                     domainId: ID_DOMAIN_RED,
-                    cardType: AGGLOMERATION_CARD_INTERFACE_NAME,
-                    cardId: 'ROAD_1',
-                  },
-                  {
-                    id: 'BBB',
-                    domainId: ID_DOMAIN_BLUE,
                     cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: 'LAND_1',
+                    cardId: ID_CLAY_PIT_RED,
                     availableResources: 0,
                   },
                   {
-                    id: 'CCC',
+                    id: 'BBB',
                     domainId: ID_DOMAIN_RED,
                     cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: 'LAND_2',
+                    cardId: ID_CLAY_PIT_RED,
                     availableResources: 3,
+                  },
+                ],
+              },
+              {
+                selector:
+                  DomainsCardsSelectors.getLandCardsPivotsIncreaseTwoProduction,
+                value: [
+                  {
+                    id: 'CCC',
+                    domainId: ID_DOMAIN_BLUE,
+                    cardType: LAND_CARD_INTERFACE_NAME,
+                    cardId: ID_FOREST_BLUE,
+                    availableResources: 0,
                   },
                   {
                     id: 'DDD',
                     domainId: ID_DOMAIN_BLUE,
                     cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: 'LAND_3',
+                    cardId: ID_FOREST_BLUE,
+                    availableResources: 2,
+                  },
+                  {
+                    id: 'EEE',
+                    domainId: ID_DOMAIN_BLUE,
+                    cardType: LAND_CARD_INTERFACE_NAME,
+                    cardId: ID_FOREST_BLUE,
+                    availableResources: 3,
                   },
                 ],
               },
@@ -127,17 +144,25 @@ describe('DomainsCardsEffects', () => {
       injector.get(MockStore);
     });
 
-    it('should dispatch updateDomainsCards with availableResources + 1 when availableResources < 3', () => {
+    it('should dispatch updateDomainsCards with availableResources + 1 when not next to a production building and availableResources < 3', () => {
       actions = hot('-a-|', {
-        a: DomainsCardsActions.increaseAvailableResourcesForDie({ die: 1 }),
+        a: DomainsCardsActions.increaseAvailableResourcesForDie({ die: 3 }),
       });
 
       const expected = hot('-a-|', {
         a: DomainsCardsActions.updateDomainsCards({
           updates: [
             {
-              id: 'BBB',
+              id: 'AAA',
               changes: { availableResources: 1 },
+            },
+            {
+              id: 'DDD',
+              changes: { availableResources: 3 },
+            },
+            {
+              id: 'CCC',
+              changes: { availableResources: 2 },
             },
           ],
         }),

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
@@ -104,15 +104,6 @@ describe('DomainsCards Selectors', () => {
       expect(result).toBe(ERROR_MSG);
     });
 
-    it('getLandCardsPivotsForDie({ die }) should return the pivot for the land card with the right die', () => {
-      const result = DomainsCardsSelectors.getLandCardsPivotsForDie(state, {
-        die: 1,
-      });
-      const selId = getDomainsCardsId(result[0]);
-
-      expect(selId).toBe('PRODUCT-BBB');
-    });
-
     it('getLandCardPivotById({ id }) should return the pivot for the id', () => {
       const result = DomainsCardsSelectors.getLandCardPivotById(state, {
         id: 'PRODUCT-BBB',
@@ -123,10 +114,10 @@ describe('DomainsCards Selectors', () => {
     });
 
     it('getLandCardPivotWithLockedResources() should return the pivot for the id', () => {
-      const result = DomainsCardsSelectors.getLandCardPivotWithLockedResources(
+      const results = DomainsCardsSelectors.getLandCardPivotWithLockedResources(
         state
       );
-      const selId = getDomainsCardsId(result[0]);
+      const selId = getDomainsCardsId(results[0]);
 
       expect(selId).toBe('PRODUCT-BBB');
     });
@@ -161,6 +152,68 @@ describe('DomainsCards Selectors', () => {
       });
 
       expect(result).toBe(0);
+    });
+  });
+
+  describe('getLandCardsPivotsIncreaseOneProduction({ die })', () => {
+    beforeEach(() => {
+      state = {
+        domainsCards: domainsCardsAdapter.setAll(
+          [
+            createDomainsCardsEntity(
+              'aaaa',
+              ID_DOMAIN_RED,
+              LAND_CARD_INTERFACE_NAME,
+              ID_CLAY_PIT_RED,
+              -2,
+              1
+            ),
+            createDomainsCardsEntity(
+              'bbbb',
+              ID_DOMAIN_BLUE,
+              LAND_CARD_INTERFACE_NAME,
+              ID_FOREST_BLUE,
+              -2,
+              -1
+            ),
+            createDomainsCardsEntity(
+              'cccc',
+              ID_DOMAIN_BLUE,
+              DEVELOPMENT_CARD_INTERFACE_NAME,
+              'BUILDING_2', // Sawmill
+              -1,
+              -1
+            ),
+          ],
+          {
+            ...initialDomainsCardsState,
+          }
+        ),
+      };
+    });
+
+    it('should return the red clay pit', () => {
+      const results = DomainsCardsSelectors.getLandCardsPivotsIncreaseOneProduction(
+        state,
+        {
+          die: 3,
+        }
+      );
+      const selId = getDomainsCardsId(results[0]);
+
+      expect(selId).toBe('aaaa');
+    });
+
+    it('should return the blue forest', () => {
+      const results = DomainsCardsSelectors.getLandCardsPivotsIncreaseTwoProduction(
+        state,
+        {
+          die: 3,
+        }
+      );
+      const selId = getDomainsCardsId(results[0]);
+
+      expect(selId).toBe('bbbb');
     });
   });
 


### PR DESCRIPTION
### Description
Add selectors to distinguish between +1 and +2 when land card next to the appropriate production building.
Use selectors in effect, to increase resources, but stay below max.

https://lhbruneton.atlassian.net/browse/TAOR-14

### Checklist
- [ ] Created tests with given/when/then blocks
- [x] Created tests for the nominal use case
- [ ] Created tests for errors
- [x] Build project without errors
