### PR TITLE
TAOR-28: Automatically increase resources on auspicious year

### DIFF
--- a/apps/taormina-duel/src/app/app.component.html
+++ b/apps/taormina-duel/src/app/app.component.html
@@ -43,6 +43,18 @@
       >
     </div>
   </div>
+  <div>
+    <p>Selected event:</p>
+    <div *ngIf="getSelectedEventsPileCard() | async as pivot">
+      <div *ngIf="getEventCard(pivot.cardId) as event">
+        {{ event.name }}
+      </div>
+    </div>
+    <hr />
+    <button type="button" (click)="removeSelectedEventsPileCard()">
+      Discard event
+    </button>
+  </div>
 </div>
 <hr />
 <div class="flex-container">

--- a/apps/taormina-duel/src/app/app.component.ts
+++ b/apps/taormina-duel/src/app/app.component.ts
@@ -116,6 +116,14 @@ export class AppComponent {
     this.game.setNextProductionDie(value);
   }
 
+  getSelectedEventsPileCard(): Observable<EventsPileCardsEntity | undefined> {
+    return this.eventsPileCards.selectedEventsPileCards$;
+  }
+
+  removeSelectedEventsPileCard(): void {
+    this.eventsPileCards.removeSelected();
+  }
+
   throwDisabled(): Observable<boolean> {
     return this.game.phase$.pipe(
       map(

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.actions.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.actions.ts
@@ -36,6 +36,10 @@ export const increaseAvailableResourcesForDie = createAction(
   props<{ die: ResourceValue }>()
 );
 
+export const increaseAvailableResourcesForAuspiciousYear = createAction(
+  '[DomainsCards] Increase Available Resources For Auspicious Year'
+);
+
 export const increaseAvailableResources = createAction(
   '[DomainsCards] Increase Available Resources',
   props<{ id: string }>()

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.spec.ts
@@ -808,4 +808,63 @@ describe('DomainsCardsEffects', () => {
       });
     });
   });
+
+  describe('increaseResourcesAuspiciousYear$', () => {
+    beforeEach(() => {
+      injector = Injector.create({
+        providers: [
+          provideMockStore({
+            selectors: [
+              {
+                selector:
+                  // FIXME: https://github.com/ngrx/platform/issues/2176
+                  DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear,
+                value: [
+                  {
+                    id: 'aaaa',
+                    domainId: ID_DOMAIN_RED,
+                    cardType: LAND_CARD_INTERFACE_NAME,
+                    cardId: ID_CLAY_PIT_RED,
+                    availableResources: 0,
+                  },
+                ],
+              },
+            ],
+          }),
+        ],
+      });
+      injector.get(MockStore);
+    });
+
+    it('should dispatch updateDomainsCards with array of changes', () => {
+      actions = hot('-a-|', {
+        a: DomainsCardsActions.increaseAvailableResourcesForAuspiciousYear(),
+      });
+
+      const expected = hot('-a-|', {
+        a: DomainsCardsActions.updateDomainsCards({
+          updates: [
+            {
+              id: 'aaaa',
+              changes: { availableResources: 1 },
+            },
+            {
+              id: 'aaaa',
+              changes: { availableResources: 2 },
+            },
+            {
+              id: 'aaaa',
+              changes: { availableResources: 3 },
+            },
+            {
+              id: 'aaaa',
+              changes: { availableResources: 3 },
+            },
+          ],
+        }),
+      });
+
+      expect(effects.increaseResourcesAuspiciousYear$).toBeObservable(expected);
+    });
+  });
 });

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.spec.ts
@@ -162,12 +162,12 @@ describe('DomainsCardsEffects', () => {
               changes: { availableResources: 1 },
             },
             {
-              id: 'DDD',
-              changes: { availableResources: 3 },
-            },
-            {
               id: 'CCC',
               changes: { availableResources: 2 },
+            },
+            {
+              id: 'DDD',
+              changes: { availableResources: 3 },
             },
           ],
         }),

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.ts
@@ -135,6 +135,49 @@ export class DomainsCardsEffects {
     return [...belowMax, ...atMax];
   };
 
+  increaseResourcesAuspiciousYear$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(DomainsCardsActions.increaseAvailableResourcesForAuspiciousYear),
+      withLatestFrom(
+        this.domainsCardsStore.select(
+          DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear,
+          { count: 1 }
+        ),
+        this.domainsCardsStore.select(
+          DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear,
+          { count: 2 }
+        ),
+        this.domainsCardsStore.select(
+          DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear,
+          { count: 3 }
+        ),
+        this.domainsCardsStore.select(
+          DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear,
+          { count: 4 }
+        )
+      ),
+      map(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        ([_action, increaseOne, increaseTwo, increaseThree, increaseFour]) => {
+          const updatesOne = this.updatesAvailableResources(increaseOne, 1);
+          /* eslint-disable no-magic-numbers */
+          const updatesTwo = this.updatesAvailableResources(increaseTwo, 2);
+          const updatesThree = this.updatesAvailableResources(increaseThree, 3);
+          const updatesFour = this.updatesAvailableResources(increaseFour, 4);
+          /* eslint-enable no-magic-numbers */
+          return DomainsCardsActions.updateDomainsCards({
+            updates: [
+              ...updatesOne,
+              ...updatesTwo,
+              ...updatesThree,
+              ...updatesFour,
+            ],
+          });
+        }
+      )
+    )
+  );
+
   lockResource$ = createEffect(() =>
     this.actions$.pipe(
       ofType(DomainsCardsActions.lockResource),

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.facade.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.facade.ts
@@ -63,6 +63,12 @@ export class DomainsCardsFacade {
     );
   }
 
+  increaseResourcesForAuspiciousYear(): void {
+    this.store.dispatch(
+      DomainsCardsActions.increaseAvailableResourcesForAuspiciousYear()
+    );
+  }
+
   useLockedResources(): void {
     this.store.dispatch(DomainsCardsActions.useLockedResources());
   }

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
@@ -1,7 +1,10 @@
 /* eslint-disable no-magic-numbers */
 import {
+  ID_CLAY_PIT_RED,
   ID_DOMAIN_BLUE,
   ID_DOMAIN_RED,
+  ID_FOREST_BLUE,
+  ID_GOLD_MINE_BLUE,
   ID_GOLD_MINE_RED,
   ID_PASTURE_BLUE,
   ID_PASTURE_RED,
@@ -10,6 +13,7 @@ import { MasteryPointsType } from '@taormina/shared-models';
 
 import {
   blueForestId,
+  domainsCardsAuspiciousYearTwoRedOneBlueState,
   domainsCardsFourTradeRedThreeTradeBlueState,
   domainsCardsNewGameState,
   domainsCardsOneStrengthRedTwoStrengthBlueState,
@@ -386,11 +390,48 @@ describe('DomainsCards Selectors', () => {
             domainId: ID_DOMAIN_BLUE,
           }
         );
-        const cardId = results[0]?.cardId;
+        const cardIdPastureBlue = results[0]?.cardId;
 
         expect(results.length).toBe(1);
-        expect(cardId).toBe(ID_PASTURE_BLUE);
+        expect(cardIdPastureBlue).toBe(ID_PASTURE_BLUE);
       });
+    });
+  });
+
+  describe('getLandCardsPivotsIncreaseAuspiciousYear', () => {
+    beforeEach(() => {
+      state = {
+        domainsCards: domainsCardsAuspiciousYearTwoRedOneBlueState(),
+      };
+    });
+    it('should return the clay pit and the pasture for the red domain with count 2', () => {
+      const results = DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear(
+        state,
+        {
+          count: 2,
+        }
+      );
+      const cardIdClayPitRed = results[0]?.cardId;
+      const cardIdPastureRed = results[1]?.cardId;
+
+      expect(results.length).toBe(2);
+      expect(cardIdClayPitRed).toBe(ID_CLAY_PIT_RED);
+      expect(cardIdPastureRed).toBe(ID_PASTURE_RED);
+    });
+
+    it('should return the forest and the gold mine for the blue domain with count 1', () => {
+      const results = DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear(
+        state,
+        {
+          count: 1,
+        }
+      );
+      const cardIdForestBlue = results[0]?.cardId;
+      const cardIdGoldMineBlue = results[1]?.cardId;
+
+      expect(results.length).toBe(2);
+      expect(cardIdForestBlue).toBe(ID_FOREST_BLUE);
+      expect(cardIdGoldMineBlue).toBe(ID_GOLD_MINE_BLUE);
     });
   });
 });

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
@@ -6,6 +6,7 @@ import {
   landCards,
 } from '@taormina/shared-constants';
 import {
+  BuildingName,
   DevelopmentCard,
   DEVELOPMENT_CARD_INTERFACE_NAME,
   DiceValue,
@@ -239,7 +240,7 @@ export const getDomainResourceCountSeenByThieves = createSelector(
         (pivot) =>
           pivot.domainId === props.domainId &&
           pivot.cardType === LAND_CARD_INTERFACE_NAME &&
-          isNextToAWarehouse(pivot, entities)
+          !isNextToAWarehouse(pivot, entities)
       )
       .reduce(
         (accumulator, domainCard) =>
@@ -258,7 +259,7 @@ export const getDomainUnprotectedGoldMinesAndPastures = createSelector(
         pivot.cardId !== undefined &&
         (landCards.get(pivot.cardId)?.type === LandType.GoldMine ||
           landCards.get(pivot.cardId)?.type === LandType.Pasture) &&
-        isNextToAWarehouse(pivot, entities)
+        !isNextToAWarehouse(pivot, entities)
     )
 );
 
@@ -269,12 +270,11 @@ const isNextToAProductionBuilding = (
 ): boolean => {
   const neighbors = getCardSideNeighbors(pivot, entities);
   return (
-    neighbors
-      .filter((neighbor) => neighbor.cardId !== undefined)
-      .find((neighbor) =>
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        isProductionBuildingForResourceType(neighbor.cardId!, landType)
-      ) !== undefined
+    neighbors.find(
+      (neighbor) =>
+        neighbor.cardId !== undefined &&
+        isProductionBuildingForResourceType(neighbor.cardId, landType)
+    ) !== undefined
   );
 };
 
@@ -282,17 +282,18 @@ const isProductionBuildingForResourceType = (
   cardId: string,
   landType: LandType
 ): boolean => {
+  const name = developmentCards.get(cardId)?.name;
   switch (landType) {
     case LandType.ClayPit:
-      return cardId === 'BUILDING_1'; // Brickyard
+      return name === BuildingName.Brickyard;
     case LandType.Forest:
-      return cardId === 'BUILDING_2'; // Sawmill
+      return name === BuildingName.Sawmill;
     case LandType.Field:
-      return cardId === 'BUILDING_3'; // Mill
+      return name === BuildingName.Mill;
     case LandType.StoneQuarry:
-      return cardId === 'BUILDING_4'; // Foundry
+      return name === BuildingName.Foundry;
     case LandType.Pasture:
-      return cardId === 'BUILDING_5'; // Weaving
+      return name === BuildingName.Weaving;
     case LandType.GoldMine:
       return false;
     // no default
@@ -307,8 +308,9 @@ const isNextToAWarehouse = (
   return (
     neighbors.find(
       (neighbor) =>
-        neighbor.cardId === 'BUILDING_6' || neighbor.cardId === 'BUILDING_7'
-    ) === undefined
+        neighbor.cardId !== undefined &&
+        developmentCards.get(neighbor.cardId)?.name === BuildingName.Warehouse
+    ) !== undefined
   );
 };
 

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
@@ -106,6 +106,24 @@ const getLandCardFilterByDie = (
   return undefined;
 };
 
+export const getLandCardsPivotsIncreaseAuspiciousYear = createSelector(
+  getAllDomainsCards,
+  (entities: DomainsCardsEntity[], props: { count: number }) =>
+    entities.filter((pivot) => {
+      if (
+        pivot.cardType === LAND_CARD_INTERFACE_NAME &&
+        pivot.cardId !== undefined
+      ) {
+        const land = landCards.get(pivot.cardId);
+        return (
+          land !== undefined &&
+          isNextToCountWarehouseOrMonastery(pivot, entities, props.count)
+        );
+      }
+      return false;
+    })
+);
+
 export const getLandCardPivotById = createSelector(
   getAllDomainsCards,
   (entities: DomainsCardsEntity[], props: { id: string }) =>
@@ -311,6 +329,24 @@ const isNextToAWarehouse = (
         neighbor.cardId !== undefined &&
         developmentCards.get(neighbor.cardId)?.name === BuildingName.Warehouse
     ) !== undefined
+  );
+};
+
+const isNextToCountWarehouseOrMonastery = (
+  pivot: DomainsCardsEntity,
+  entities: DomainsCardsEntity[],
+  count: number
+): boolean => {
+  const neighbors = getCardSideNeighbors(pivot, entities);
+  return (
+    neighbors.filter(
+      (neighbor) =>
+        neighbor.cardId !== undefined &&
+        (developmentCards.get(neighbor.cardId)?.name ===
+          BuildingName.Warehouse ||
+          developmentCards.get(neighbor.cardId)?.name ===
+            BuildingName.Monastery)
+    ).length === count
   );
 };
 

--- a/libs/data-access-game/src/test/fixtures/domains-cards.ts
+++ b/libs/data-access-game/src/test/fixtures/domains-cards.ts
@@ -10,13 +10,13 @@ import { DomainsCardsState } from '../../lib/+state/domains-cards/domains-cards.
 export const someId = '7a1e11aa-47bb-4b4e-94ab-4c91c19e6a62';
 export const redClayPitId = '9ed2d3b8-1d98-4331-969e-09b7f1ba046e';
 export const blueForestId = 'fb675e2e-ee40-4e07-b29c-d6dbd823ca53';
+const nextToRedClayPit = '444bebc9-2521-49f0-b790-2668a4baa182';
 const nextToBlueForestId = '762a3af1-c807-4fd6-b0f5-c5ec52c1c619';
 const redAvailableDevelopmentSlotOneId = '83bada45-309e-4ca6-b59f-e499fdc01b6e';
 const redAvailableDevelopmentSlotTwoId = '82ef1e96-e9d2-4e35-9014-2b825e3c2904';
 const redAvailableDevelopmentSlotThreeId =
   '66d9fc21-e2c0-40ab-88b1-1d87b32022af';
-const redAvailableDevelopmentSlotFourId =
-  '444bebc9-2521-49f0-b790-2668a4baa182';
+const redAvailableDevelopmentSlotFourId = nextToRedClayPit;
 const blueAvailableDevelopmentSlotOneId = nextToBlueForestId;
 const blueAvailableDevelopmentSlotTwoId =
   '17dc5ec7-8351-4b0c-8797-688cbafb9a2f';
@@ -71,7 +71,7 @@ const domainsCardsNewGameStateIds = [
   '9c9eac6c-f1c8-42a7-92b9-4d6ac4067310',
   redAvailableDevelopmentSlotThreeId,
   '25ee1175-17c7-4f4e-8c35-ea99ee9f1751',
-  redAvailableDevelopmentSlotFourId,
+  nextToRedClayPit,
   '3eb0bc9f-23cc-4e61-a53d-95b60da4dd1e',
   '77c56483-29b6-49d2-b332-18536aeb6ae3',
   '4d84a04a-3048-4ffc-9d53-c07ed61a9fe9',
@@ -216,8 +216,8 @@ export const domainsCardsNewGameStateEntities = {
     availableResources: 1,
     lockedResources: 0,
   } as DomainsCardsEntity,
-  [redAvailableDevelopmentSlotFourId]: {
-    id: redAvailableDevelopmentSlotFourId,
+  [nextToRedClayPit]: {
+    id: nextToRedClayPit,
     domainId: 'DOMAIN_RED',
     cardType: 'AvailableDevelopmentSlot',
     col: -1,
@@ -700,6 +700,40 @@ export const domainsCardsWarehouseNextToBlueForestState = (): DomainsCardsState 
     entities: {
       ...newEntities,
       aaaa: aaaaWarehouseNextToBlueForestDomainCard,
+    },
+  };
+  return domainsCards;
+};
+
+export const domainsCardsAuspiciousYearTwoRedOneBlueState = (): DomainsCardsState => {
+  const newIds = (domainsCardsWarehouseNextToBlueForestState()
+    .ids as string[]).filter((id) => id !== nextToRedClayPit);
+  const newEntities = {
+    ...domainsCardsWarehouseNextToBlueForestState().entities,
+  };
+  delete newEntities[nextToRedClayPit];
+
+  const domainsCards = {
+    ...domainsCardsWarehouseNextToBlueForestState(),
+    ids: [...newIds, 'bbbb', 'cccc'],
+    entities: {
+      ...newEntities,
+      bbbb: createDomainsCardsEntity(
+        'bbbb',
+        ID_DOMAIN_RED,
+        DEVELOPMENT_CARD_INTERFACE_NAME,
+        'BUILDING_12', // Monastery
+        -1,
+        -1
+      ),
+      cccc: createDomainsCardsEntity(
+        'cccc',
+        ID_DOMAIN_RED,
+        DEVELOPMENT_CARD_INTERFACE_NAME,
+        'BUILDING_7', // Warehouse
+        -1,
+        -2
+      ),
     },
   };
   return domainsCards;

--- a/libs/feature-engine/src/lib/game-rules.service.spec.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.spec.ts
@@ -131,11 +131,11 @@ describe('GameRulesService', () => {
     );
   });
 
-  describe('increaseResources$', () => {
+  describe('increaseResourcesForDie$', () => {
     it(
       'should complete on gameEnded',
       marbles((m) => {
-        // Given a stream of productions and an increaseResources$ stream build on it
+        // Given a stream of productions and an increaseResourcesForDie$ stream build on it
         const productionDie$ = m.hot('^-a-b-|', {
           a: 5,
           b: 3,
@@ -150,9 +150,9 @@ describe('GameRulesService', () => {
         service = TestBed.inject(GameRulesService);
         // When the gameEnded$ subject emits
         m.cold('---a-|').subscribe(() => service.gameEnded$.next());
-        // Then the increaseResources$ stream completes
+        // Then the increaseResourcesForDie$ stream completes
         const expected$ = m.cold('--a|', { a: undefined });
-        m.expect(service.increaseResources$).toBeObservable(expected$);
+        m.expect(service.increaseResourcesForDie$).toBeObservable(expected$);
       })
     );
   });
@@ -212,8 +212,8 @@ describe('GameRulesService', () => {
         service.countAndSteal$,
         'subscribe'
       );
-      const increaseResourcesSubscribeSpy = jest.spyOn(
-        service.increaseResources$,
+      const increaseResourcesForDieSubscribeSpy = jest.spyOn(
+        service.increaseResourcesForDie$,
         'subscribe'
       );
 
@@ -221,7 +221,7 @@ describe('GameRulesService', () => {
 
       expect(gameEndedNextSpy).toHaveBeenCalledTimes(1);
       expect(countAndStealSubscribeSpy).toHaveBeenCalledTimes(1);
-      expect(increaseResourcesSubscribeSpy).toHaveBeenCalledTimes(1);
+      expect(increaseResourcesForDieSubscribeSpy).toHaveBeenCalledTimes(1);
 
       expect(gameFacadeMock.initNewGame).toHaveBeenCalledTimes(1);
       expect(domainsCardsFacadeMock.initNewGame).toHaveBeenCalledTimes(1);

--- a/libs/feature-engine/src/lib/game-rules.service.spec.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.spec.ts
@@ -62,32 +62,62 @@ describe('GameRulesService', () => {
     }
   ));
 
-  describe('thieves$', () => {
-    it(
-      'should filter events other than thieves',
-      marbles((m) => {
-        // Given a stream of events
-        const eventDie$ = m.hot('^-a-b-c-|', {
-          a: EventValue.Event,
-          b: EventValue.Thieves,
-          c: EventValue.Trade,
-        });
-        // When the thieves$ stream is build on it
-        const gameFacadeMock = {
-          eventDie$,
-          productionDie$: of(),
-        };
-        TestBed.configureTestingModule({
-          providers: [{ provide: GameFacade, useValue: gameFacadeMock }],
-        });
-        service = TestBed.inject(GameRulesService);
-        // Then only thieves events should remain
-        const expected$ = m.cold('----a---|', {
-          a: EventValue.Thieves,
-        });
-        m.expect(service.thieves$).toBeObservable(expected$);
-      })
-    );
+  describe('eventDie$', () => {
+    describe('event$', () => {
+      it(
+        'should filter events other than event',
+        marbles((m) => {
+          // Given a stream of events
+          const eventDie$ = m.hot('^-a-b-c-|', {
+            a: EventValue.Event,
+            b: EventValue.Thieves,
+            c: EventValue.Trade,
+          });
+          // When the event$ stream is build on it
+          const gameFacadeMock = {
+            eventDie$,
+            productionDie$: of(),
+          };
+          TestBed.configureTestingModule({
+            providers: [{ provide: GameFacade, useValue: gameFacadeMock }],
+          });
+          service = TestBed.inject(GameRulesService);
+          // Then only event events should remain
+          const expected$ = m.cold('--a-----|', {
+            a: EventValue.Event,
+          });
+          m.expect(service.event$).toBeObservable(expected$);
+        })
+      );
+    });
+
+    describe('thieves$', () => {
+      it(
+        'should filter events other than thieves',
+        marbles((m) => {
+          // Given a stream of events
+          const eventDie$ = m.hot('^-a-b-c-|', {
+            a: EventValue.Event,
+            b: EventValue.Thieves,
+            c: EventValue.Trade,
+          });
+          // When the thieves$ stream is build on it
+          const gameFacadeMock = {
+            eventDie$,
+            productionDie$: of(),
+          };
+          TestBed.configureTestingModule({
+            providers: [{ provide: GameFacade, useValue: gameFacadeMock }],
+          });
+          service = TestBed.inject(GameRulesService);
+          // Then only thieves events should remain
+          const expected$ = m.cold('----a---|', {
+            a: EventValue.Thieves,
+          });
+          m.expect(service.thieves$).toBeObservable(expected$);
+        })
+      );
+    });
   });
 
   describe('countAndSteal$', () => {
@@ -131,6 +161,82 @@ describe('GameRulesService', () => {
     );
   });
 
+  describe('selectFirstEvent$', () => {
+    it(
+      `should call selectFirst on event and complete on gameEnded`,
+      marbles((m) => {
+        // Given a stream of event events
+        const eventDie$ = m.hot('^-a-a-|', {
+          a: EventValue.Event,
+        });
+        // Given a selectFirstEvent$ stream build on it
+        const gameFacadeMock = {
+          eventDie$,
+          productionDie$: of(),
+        };
+        const eventsPileCardsFacadeMock = {
+          selectedEventsPileCards$: of(),
+          selectFirst: jest.fn(),
+        };
+        TestBed.configureTestingModule({
+          providers: [
+            { provide: GameFacade, useValue: gameFacadeMock },
+            {
+              provide: EventsPileCardsFacade,
+              useValue: eventsPileCardsFacadeMock,
+            },
+          ],
+        });
+        service = TestBed.inject(GameRulesService);
+        // When the gameEnded$ subject emits
+        m.cold('---a-|').subscribe(() => service.gameEnded$.next());
+        // Then the selectFirstEvent$ stream completes
+        const expected$ = m.cold('--a|', { a: undefined });
+        m.expect(service.selectFirstEvent$).toBeObservable(expected$);
+        // Then call selectFirst on event before completion
+        service.selectFirstEvent$.pipe(
+          tap(() => {
+            expect(eventsPileCardsFacadeMock.selectFirst).toHaveBeenCalledTimes(
+              1
+            );
+          })
+        );
+      })
+    );
+  });
+
+  describe('auspiciousYear$', () => {
+    it(
+      'should filter events other than thieves',
+      marbles((m) => {
+        // Given a stream of selected events pile cards
+        const selectedEventsPileCards$ = m.hot('^-a-b-c-|', {
+          a: undefined,
+          b: { id: 'aaaa', cardId: 'EVENT_1' },
+          c: { id: 'bbbb', cardId: 'EVENT_0' },
+        });
+        // When the auspiciousYear$ stream is build on it
+        const eventsPileCardsFacadeMock = {
+          selectedEventsPileCards$,
+        };
+        TestBed.configureTestingModule({
+          providers: [
+            {
+              provide: EventsPileCardsFacade,
+              useValue: eventsPileCardsFacadeMock,
+            },
+          ],
+        });
+        service = TestBed.inject(GameRulesService);
+        // Then only auspicious year events should remain
+        const expected$ = m.cold('----a---|', {
+          a: { id: 'aaaa', cardId: 'EVENT_1' },
+        });
+        m.expect(service.auspiciousYear$).toBeObservable(expected$);
+      })
+    );
+  });
+
   describe('increaseResourcesForDie$', () => {
     it(
       'should complete on gameEnded',
@@ -157,6 +263,54 @@ describe('GameRulesService', () => {
     );
   });
 
+  describe('increaseResourcesForAuspiciousYear$', () => {
+    it(
+      `should call increaseResourcesForAuspiciousYear on event and complete on gameEnded`,
+      marbles((m) => {
+        // Given a stream of auspicious year events
+        const selectedEventsPileCards$ = m.hot('^-a-b-|', {
+          a: { id: 'aaaa', cardId: 'EVENT_1' },
+          b: { id: 'bbbb', cardId: 'EVENT_2' },
+        });
+        // Given a increaseResourcesForAuspiciousYear$ stream build on it
+        const domainsCardsFacadeMock = {
+          increaseResourcesForAuspiciousYear: jest.fn(),
+        };
+        const eventsPileCardsFacadeMock = {
+          selectedEventsPileCards$,
+        };
+        TestBed.configureTestingModule({
+          providers: [
+            {
+              provide: DomainsCardsFacade,
+              useValue: domainsCardsFacadeMock,
+            },
+            {
+              provide: EventsPileCardsFacade,
+              useValue: eventsPileCardsFacadeMock,
+            },
+          ],
+        });
+        service = TestBed.inject(GameRulesService);
+        // When the gameEnded$ subject emits
+        m.cold('---a-|').subscribe(() => service.gameEnded$.next());
+        // Then the increaseResourcesForAuspiciousYear$ stream completes
+        const expected$ = m.cold('--a|', { a: undefined });
+        m.expect(service.increaseResourcesForAuspiciousYear$).toBeObservable(
+          expected$
+        );
+        // Then call increaseResourcesForAuspiciousYear on event before completion
+        service.increaseResourcesForAuspiciousYear$.pipe(
+          tap(() => {
+            expect(
+              domainsCardsFacadeMock.increaseResourcesForAuspiciousYear
+            ).toHaveBeenCalledTimes(1);
+          })
+        );
+      })
+    );
+  });
+
   describe('initNewGame', () => {
     const gameFacadeMock = {
       eventDie$: of(),
@@ -179,6 +333,7 @@ describe('GameRulesService', () => {
       initNewGame: jest.fn(),
     };
     const eventsPileCardsFacadeMock = {
+      selectedEventsPileCards$: of(),
       initNewGame: jest.fn(),
     };
 
@@ -212,8 +367,16 @@ describe('GameRulesService', () => {
         service.countAndSteal$,
         'subscribe'
       );
+      const selectFirstEventSubscribeSpy = jest.spyOn(
+        service.selectFirstEvent$,
+        'subscribe'
+      );
       const increaseResourcesForDieSubscribeSpy = jest.spyOn(
         service.increaseResourcesForDie$,
+        'subscribe'
+      );
+      const increaseResourcesForAuspiciousYearSubscribeSpy = jest.spyOn(
+        service.increaseResourcesForAuspiciousYear$,
         'subscribe'
       );
 
@@ -221,7 +384,11 @@ describe('GameRulesService', () => {
 
       expect(gameEndedNextSpy).toHaveBeenCalledTimes(1);
       expect(countAndStealSubscribeSpy).toHaveBeenCalledTimes(1);
+      expect(selectFirstEventSubscribeSpy).toHaveBeenCalledTimes(1);
       expect(increaseResourcesForDieSubscribeSpy).toHaveBeenCalledTimes(1);
+      expect(
+        increaseResourcesForAuspiciousYearSubscribeSpy
+      ).toHaveBeenCalledTimes(1);
 
       expect(gameFacadeMock.initNewGame).toHaveBeenCalledTimes(1);
       expect(domainsCardsFacadeMock.initNewGame).toHaveBeenCalledTimes(1);

--- a/libs/feature-engine/src/lib/game-rules.service.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.ts
@@ -41,7 +41,7 @@ export class GameRulesService {
     })
   );
 
-  increaseResources$ = this.game.productionDie$.pipe(
+  increaseResourcesForDie$ = this.game.productionDie$.pipe(
     takeUntil(this.gameEnded$),
     filter((value): value is DiceValue => value !== undefined),
     map((value) => this.domainsCards.increaseResourcesForDie(value))
@@ -60,7 +60,7 @@ export class GameRulesService {
   initNewGame(): void {
     this.gameEnded$.next();
     this.countAndSteal$.subscribe();
-    this.increaseResources$.subscribe();
+    this.increaseResourcesForDie$.subscribe();
 
     this.game.initNewGame();
     this.domainsCards.initNewGame();

--- a/libs/feature-engine/src/lib/game-rules.service.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import {
   DomainsCardsFacade,
+  EventsPileCardsEntity,
   EventsPileCardsFacade,
   FaceUpPilesCardsFacade,
   GameFacade,
@@ -8,7 +9,11 @@ import {
   LandsPileCardsFacade,
   StockPilesCardsFacade,
 } from '@taormina/data-access-game';
-import { ID_FACE_UP_HAMLET, ID_FACE_UP_TOWN } from '@taormina/shared-constants';
+import {
+  eventCards,
+  ID_FACE_UP_HAMLET,
+  ID_FACE_UP_TOWN,
+} from '@taormina/shared-constants';
 import {
   AGGLOMERATION_CARD_INTERFACE_NAME,
   AVAILABLE_AGGLOMERATION_SLOT,
@@ -16,6 +21,7 @@ import {
   AVAILABLE_LAND_SLOT,
   DEVELOPMENT_CARD_INTERFACE_NAME,
   DiceValue,
+  EventName,
   EventValue,
   GamePhase,
   LAND_CARD_INTERFACE_NAME,
@@ -30,6 +36,8 @@ import { filter, map, take, takeUntil } from 'rxjs/operators';
 export class GameRulesService {
   gameEnded$ = new Subject();
 
+  event$ = this.game.eventDie$.pipe(filter((die) => die === EventValue.Event));
+
   thieves$ = this.game.eventDie$.pipe(
     filter((die) => die === EventValue.Thieves)
   );
@@ -41,10 +49,29 @@ export class GameRulesService {
     })
   );
 
+  selectFirstEvent$ = this.event$.pipe(
+    takeUntil(this.gameEnded$),
+    map(() => {
+      this.eventsPileCards.selectFirst();
+    })
+  );
+
+  auspiciousYear$ = this.eventsPileCards.selectedEventsPileCards$.pipe(
+    filter((pivot): pivot is EventsPileCardsEntity => pivot !== undefined),
+    filter(
+      (pivot) => eventCards.get(pivot.cardId)?.name === EventName.AuspiciousYear
+    )
+  );
+
   increaseResourcesForDie$ = this.game.productionDie$.pipe(
     takeUntil(this.gameEnded$),
     filter((value): value is DiceValue => value !== undefined),
     map((value) => this.domainsCards.increaseResourcesForDie(value))
+  );
+
+  increaseResourcesForAuspiciousYear$ = this.auspiciousYear$.pipe(
+    takeUntil(this.gameEnded$),
+    map(() => this.domainsCards.increaseResourcesForAuspiciousYear())
   );
 
   constructor(
@@ -60,7 +87,9 @@ export class GameRulesService {
   initNewGame(): void {
     this.gameEnded$.next();
     this.countAndSteal$.subscribe();
+    this.selectFirstEvent$.subscribe();
     this.increaseResourcesForDie$.subscribe();
+    this.increaseResourcesForAuspiciousYear$.subscribe();
 
     this.game.initNewGame();
     this.domainsCards.initNewGame();


### PR DESCRIPTION
### Description
Select land cards next to warehouse or monastery.
Select first event card on event event.
Build auspicious year stream on selected event card stream.
Increase resources automatically.

https://lhbruneton.atlassian.net/browse/TAOR-28

### Checklist
- [x] Created tests with given/when/then blocks
- [x] Created tests for the nominal use case
- [ ] Created tests for errors
- [x] Build project without errors
