### PR TITLE
TAOR-36: Reset events pile on festival event

### DIFF
--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.reducer.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.reducer.spec.ts
@@ -8,7 +8,7 @@ import {
   domainsCardsNewGameStateEntities,
   redClayPitDomainCard,
   redClayPitId,
-  someId,
+  someDomainsCardsId,
 } from '../../../test';
 import * as DomainsCardsActions from './domains-cards.actions';
 import {
@@ -151,11 +151,11 @@ describe('DomainsCards Reducer', () => {
     it('should select the DomainCard', () => {
       const newState = {
         ...domainsCardsNewGameState,
-        selectedId: someId,
+        selectedId: someDomainsCardsId,
       };
 
       const action = DomainsCardsActions.selectDomainCard({
-        id: someId,
+        id: someDomainsCardsId,
       });
 
       const state: DomainsCardsState = domainsCardsReducer(

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
@@ -27,7 +27,7 @@ import {
   domainsCardsWarehouseNextToBlueForestState,
   redClayPitDomainCard,
   redClayPitId,
-  someId,
+  someDomainsCardsId,
 } from '../../../test';
 import { DomainsCardsEntity } from './domains-cards.models';
 import { DomainsCardsPartialState } from './domains-cards.reducer';
@@ -62,7 +62,7 @@ describe('DomainsCards Selectors', () => {
       state = {
         domainsCards: {
           ...domainsCardsNewGameState,
-          selectedId: someId,
+          selectedId: someDomainsCardsId,
         },
       };
     });
@@ -70,7 +70,7 @@ describe('DomainsCards Selectors', () => {
       const result = DomainsCardsSelectors.getDomainsCardsSelected(state);
       const selId = getDomainsCardsId(result);
 
-      expect(selId).toBe(someId);
+      expect(selId).toBe(someDomainsCardsId);
     });
   });
 

--- a/libs/data-access-game/src/lib/+state/events-pile-cards/events-pile-cards.actions.ts
+++ b/libs/data-access-game/src/lib/+state/events-pile-cards/events-pile-cards.actions.ts
@@ -19,15 +19,7 @@ export const loadEventsPileCardsFailure = createAction(
   props<{ error: string }>()
 );
 
-export const setEventsPileCardsInitialized = createAction(
-  '[EventsPileCards] Set EventsPileCards On Init',
-  props<{ eventsPileCards: EventsPileCardsEntity[] }>()
-);
-
-export const setEventsPileCardsError = createAction(
-  '[EventsPileCards] Set EventsPileCards Error',
-  props<{ error: string }>()
-);
+export const resetEventsPile = createAction('[Game Rules] Reset Events Pile');
 
 export const selectFirstEventsPileCard = createAction(
   '[EventsPileCards] Select First Events Pile Card'
@@ -35,6 +27,21 @@ export const selectFirstEventsPileCard = createAction(
 
 export const removeSelectedEventsPileCard = createAction(
   '[EventsPileCards] Remove Selected Events Pile Card'
+);
+
+export const setEntitiesSelectFirstEventsPileCards = createAction(
+  '[EventsPileCards] Set Entities Select First EventsPileCards',
+  props<{ eventsPileCards: EventsPileCardsEntity[] }>()
+);
+
+export const setEntitiesInitializedEventsPileCards = createAction(
+  '[EventsPileCards] Set EventsPileCards Initialized Status',
+  props<{ eventsPileCards: EventsPileCardsEntity[] }>()
+);
+
+export const setEventsPileCardsError = createAction(
+  '[EventsPileCards] Set EventsPileCards Error',
+  props<{ error: string }>()
 );
 
 export const selectEventsPileCard = createAction(

--- a/libs/data-access-game/src/lib/+state/events-pile-cards/events-pile-cards.effects.spec.ts
+++ b/libs/data-access-game/src/lib/+state/events-pile-cards/events-pile-cards.effects.spec.ts
@@ -1,15 +1,13 @@
-import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
-import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { provideMockStore } from '@ngrx/store/testing';
 import { DataPersistence, NxModule } from '@nrwl/angular';
 import { hot } from '@nrwl/angular/testing';
 import { Observable } from 'rxjs';
 
 import * as EventsPileCardsActions from './events-pile-cards.actions';
 import { EventsPileCardsEffects } from './events-pile-cards.effects';
-import * as EventsPileCardsSelectors from './events-pile-cards.selectors';
 
 jest.mock('./events-pile-cards.models', () => {
   return {
@@ -19,7 +17,6 @@ jest.mock('./events-pile-cards.models', () => {
 });
 
 describe('EventsPileCardsEffects', () => {
-  let injector: Injector;
   let actions: Observable<Action>;
   let effects: EventsPileCardsEffects;
 
@@ -38,13 +35,14 @@ describe('EventsPileCardsEffects', () => {
   });
 
   describe('initNewGame$', () => {
-    it('should work', () => {
+    it(`should call setEntitiesInitializedEventsPileCards
+        with a mocked empty array of entities`, () => {
       actions = hot('-a-|', {
         a: EventsPileCardsActions.initEventsPileCardsNewGame(),
       });
 
       const expected = hot('-a-|', {
-        a: EventsPileCardsActions.setEventsPileCardsInitialized({
+        a: EventsPileCardsActions.setEntitiesInitializedEventsPileCards({
           eventsPileCards: [],
         }),
       });
@@ -69,77 +67,20 @@ describe('EventsPileCardsEffects', () => {
     });
   });
 
-  describe('selectFirst$', () => {
-    beforeEach(() => {
-      injector = Injector.create({
-        providers: [
-          provideMockStore({
-            selectors: [
-              {
-                selector: EventsPileCardsSelectors.getAllEventsPileCards,
-                value: [
-                  {
-                    id: 'aaaa',
-                    cardId: 'EVENT_0',
-                  },
-                  {
-                    id: 'bbbb',
-                    cardId: 'EVENT_1',
-                  },
-                ],
-              },
-            ],
-          }),
-        ],
-      });
-      injector.get(MockStore);
-    });
-
-    it('should select the first events pile card', () => {
+  describe('resetPileAndSelectFirst$', () => {
+    it(`should call setEntitiesSelectFirstEventsPileCards
+        with a mocked empty array of entities`, () => {
       actions = hot('-a-|', {
-        a: EventsPileCardsActions.selectFirstEventsPileCard(),
+        a: EventsPileCardsActions.resetEventsPile(),
       });
 
       const expected = hot('-a-|', {
-        a: EventsPileCardsActions.selectEventsPileCard({
-          id: 'aaaa',
+        a: EventsPileCardsActions.setEntitiesSelectFirstEventsPileCards({
+          eventsPileCards: [],
         }),
       });
 
-      expect(effects.selectFirst$).toBeObservable(expected);
-    });
-  });
-
-  describe('removeSelected$', () => {
-    beforeEach(() => {
-      injector = Injector.create({
-        providers: [
-          provideMockStore({
-            selectors: [
-              {
-                selector: EventsPileCardsSelectors.getEventsPileCardsSelectedId,
-                value: 'aaaa',
-              },
-            ],
-          }),
-        ],
-      });
-      injector.get(MockStore);
-    });
-
-    it('should remove the selected events pile card', () => {
-      actions = hot('-a----|', {
-        a: EventsPileCardsActions.removeSelectedEventsPileCard(),
-      });
-
-      const expected = hot('-(ab)-|', {
-        a: EventsPileCardsActions.removeEventsPileCard({
-          id: 'aaaa',
-        }),
-        b: EventsPileCardsActions.unselectEventsPileCard(),
-      });
-
-      expect(effects.removeSelected$).toBeObservable(expected);
+      expect(effects.resetPileAndSelectFirst$).toBeObservable(expected);
     });
   });
 });

--- a/libs/data-access-game/src/lib/+state/events-pile-cards/events-pile-cards.effects.ts
+++ b/libs/data-access-game/src/lib/+state/events-pile-cards/events-pile-cards.effects.ts
@@ -2,11 +2,10 @@ import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { fetch } from '@nrwl/angular';
-import { filter, map, switchMap, withLatestFrom } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import * as EventsPileCardsActions from './events-pile-cards.actions';
 import { createInitialEventsPileCards } from './events-pile-cards.models';
 import * as EventsPileCardsFeature from './events-pile-cards.reducer';
-import * as EventsPileCardsSelectors from './events-pile-cards.selectors';
 
 @Injectable()
 export class EventsPileCardsEffects {
@@ -14,7 +13,7 @@ export class EventsPileCardsEffects {
     this.actions$.pipe(
       ofType(EventsPileCardsActions.initEventsPileCardsNewGame),
       map(() =>
-        EventsPileCardsActions.setEventsPileCardsInitialized({
+        EventsPileCardsActions.setEntitiesInitializedEventsPileCards({
           eventsPileCards: createInitialEventsPileCards(),
         })
       )
@@ -40,41 +39,14 @@ export class EventsPileCardsEffects {
     )
   );
 
-  selectFirst$ = createEffect(() =>
+  resetPileAndSelectFirst$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(EventsPileCardsActions.selectFirstEventsPileCard),
-      withLatestFrom(
-        this.eventsPileCardsStore.select(
-          EventsPileCardsSelectors.getAllEventsPileCards
-        )
-      ),
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      map(([_action, pivots]) => {
-        return EventsPileCardsActions.selectEventsPileCard({
-          id: pivots[0].id,
-        });
-      })
-    )
-  );
-
-  removeSelected$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(EventsPileCardsActions.removeSelectedEventsPileCard),
-      withLatestFrom(
-        this.eventsPileCardsStore.select(
-          EventsPileCardsSelectors.getEventsPileCardsSelectedId
-        )
-      ),
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      filter(([_action, selectedId]) => selectedId !== undefined),
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      switchMap(([_action, selectedId]) => [
-        EventsPileCardsActions.removeEventsPileCard({
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          id: selectedId!,
-        }),
-        EventsPileCardsActions.unselectEventsPileCard(),
-      ])
+      ofType(EventsPileCardsActions.resetEventsPile),
+      map(() =>
+        EventsPileCardsActions.setEntitiesSelectFirstEventsPileCards({
+          eventsPileCards: createInitialEventsPileCards(),
+        })
+      )
     )
   );
 

--- a/libs/data-access-game/src/lib/+state/events-pile-cards/events-pile-cards.facade.ts
+++ b/libs/data-access-game/src/lib/+state/events-pile-cards/events-pile-cards.facade.ts
@@ -37,6 +37,10 @@ export class EventsPileCardsFacade {
     this.store.dispatch(EventsPileCardsActions.initEventsPileCardsSavedGame());
   }
 
+  resetEventsPile(): void {
+    this.store.dispatch(EventsPileCardsActions.resetEventsPile());
+  }
+
   selectFirst(): void {
     this.store.dispatch(EventsPileCardsActions.selectFirstEventsPileCard());
   }

--- a/libs/data-access-game/src/lib/+state/events-pile-cards/events-pile-cards.reducer.spec.ts
+++ b/libs/data-access-game/src/lib/+state/events-pile-cards/events-pile-cards.reducer.spec.ts
@@ -1,10 +1,18 @@
 import { Action } from '@ngrx/store';
+
+import {
+  eventsPileCardsNewGameState,
+  eventsPileCardsNewGameStateEntities,
+  eventsPileCardsNewGameStateIds,
+  eventsPileCardsRemovedSelectedState,
+  eventsPileCardsSelectedState,
+} from '../../../test';
 import * as EventsPileCardsActions from './events-pile-cards.actions';
 import { createEventsPileCardsEntity } from './events-pile-cards.models';
 import {
+  eventsPileCardsReducer,
   EventsPileCardsState,
   initialEventsPileCardsState,
-  eventsPileCardsReducer,
 } from './events-pile-cards.reducer';
 
 describe('EventsPileCards Reducer', () => {
@@ -88,106 +96,73 @@ describe('EventsPileCards Reducer', () => {
     });
   });
 
-  describe('selectEventsPileCard', () => {
-    it('should set the selectedId', () => {
-      const newState: EventsPileCardsState = {
-        ids: [],
-        entities: {},
-        initialized: false,
-        loaded: true,
-        selectedId: 'PRODUCT-AAA',
-      };
-
-      const initialState: EventsPileCardsState = {
-        ids: [],
-        entities: {},
-        initialized: false,
-        loaded: true,
-      };
-
-      const action = EventsPileCardsActions.selectEventsPileCard({
-        id: 'PRODUCT-AAA',
-      });
+  describe('setEntitiesInitializedEventsPileCards', () => {
+    it('should set the list of known EventsPileCards and intialized', () => {
+      const action = EventsPileCardsActions.setEntitiesInitializedEventsPileCards(
+        {
+          eventsPileCards: Object.values(eventsPileCardsNewGameStateEntities),
+        }
+      );
 
       const state: EventsPileCardsState = eventsPileCardsReducer(
-        initialState,
+        initialEventsPileCardsState,
         action
       );
 
-      expect(state).toEqual(newState);
+      expect(state).toEqual({
+        ...eventsPileCardsNewGameState,
+      });
     });
   });
 
-  describe('unselectEventsPileCard', () => {
-    it('should unset the selectedId', () => {
-      const newState: EventsPileCardsState = {
-        ids: [],
-        entities: {},
-        initialized: false,
-        loaded: true,
-      };
-
-      const initialState: EventsPileCardsState = {
-        ids: [],
-        entities: {},
-        initialized: false,
-        loaded: true,
-        selectedId: 'PRODUCT-AAA',
-      };
-
-      const action = EventsPileCardsActions.unselectEventsPileCard();
+  describe('setEntitiesSelectFirstEventsPileCards', () => {
+    it(`should set the list of known EventsPileCards
+        and select the first card of the pile`, () => {
+      const action = EventsPileCardsActions.setEntitiesSelectFirstEventsPileCards(
+        {
+          eventsPileCards: Object.values(eventsPileCardsNewGameStateEntities),
+        }
+      );
 
       const state: EventsPileCardsState = eventsPileCardsReducer(
-        initialState,
+        { ...initialEventsPileCardsState, initialized: true },
         action
       );
 
-      expect(state).toEqual(newState);
+      expect(state).toEqual({
+        ...eventsPileCardsNewGameState,
+        selectedId: eventsPileCardsNewGameStateIds[0],
+      });
     });
   });
 
-  describe('removeEventsPileCard', () => {
-    it('should remove the pivot with the selectedId', () => {
-      const newState: EventsPileCardsState = {
-        ids: ['PRODUCT-zzz'],
-        entities: {
-          'PRODUCT-zzz': {
-            id: 'PRODUCT-zzz',
-            cardId: 'z',
-          },
-        },
-        initialized: false,
-        loaded: true,
-        selectedId: 'PRODUCT-AAA',
-      };
-
-      const initialState: EventsPileCardsState = {
-        ids: ['PRODUCT-AAA', 'PRODUCT-zzz'],
-        entities: {
-          'PRODUCT-AAA': {
-            id: 'PRODUCT-AAA',
-            cardId: 'A',
-          },
-          'PRODUCT-zzz': {
-            id: 'PRODUCT-zzz',
-            cardId: 'z',
-          },
-        },
-        initialized: false,
-        loaded: true,
-        selectedId: 'PRODUCT-AAA',
-      };
-
-      const action = EventsPileCardsActions.removeEventsPileCard({
-        id: 'PRODUCT-AAA',
-      });
+  describe('selectFirstEventsPileCard', () => {
+    it('should set the selectedId to the first card of the pile', () => {
+      const action = EventsPileCardsActions.selectFirstEventsPileCard();
 
       const state: EventsPileCardsState = eventsPileCardsReducer(
-        initialState,
+        eventsPileCardsNewGameState,
         action
       );
 
-      expect(state).toEqual(newState);
+      expect(state).toEqual({
+        ...eventsPileCardsNewGameState,
+        selectedId: eventsPileCardsNewGameStateIds[0],
+      });
+    });
+  });
+
+  describe('removeSelectedEventsPileCard', () => {
+    it(`should remove the selected card from the pile
+        and set selectedId to undefined`, () => {
+      const action = EventsPileCardsActions.removeSelectedEventsPileCard();
+
+      const state: EventsPileCardsState = eventsPileCardsReducer(
+        eventsPileCardsSelectedState(),
+        action
+      );
+
+      expect(state).toEqual(eventsPileCardsRemovedSelectedState());
     });
   });
 });

--- a/libs/data-access-game/src/lib/+state/events-pile-cards/events-pile-cards.reducer.ts
+++ b/libs/data-access-game/src/lib/+state/events-pile-cards/events-pile-cards.reducer.ts
@@ -34,6 +34,7 @@ export const eventsPileCardsReducer = createReducer(
   on(EventsPileCardsActions.initEventsPileCardsNewGame, (state) => ({
     ...state,
     initialized: false,
+    selectedId: undefined,
   })),
   on(EventsPileCardsActions.initEventsPileCardsSavedGame, (state) => ({
     ...state,
@@ -49,27 +50,42 @@ export const eventsPileCardsReducer = createReducer(
     ...state,
     errorMsg: error,
   })),
+  on(EventsPileCardsActions.setEventsPileCardsError, (state, { error }) => ({
+    ...state,
+    errorMsg: error,
+  })),
   on(
-    EventsPileCardsActions.setEventsPileCardsInitialized,
+    EventsPileCardsActions.setEntitiesInitializedEventsPileCards,
     (state, { eventsPileCards }) =>
       eventsPileCardsAdapter.setAll(eventsPileCards, {
         ...state,
         initialized: true,
       })
   ),
-  on(EventsPileCardsActions.setEventsPileCardsError, (state, { error }) => ({
+  on(
+    EventsPileCardsActions.setEntitiesSelectFirstEventsPileCards,
+    (state, { eventsPileCards }) =>
+      eventsPileCardsAdapter.setAll(eventsPileCards, {
+        ...state,
+        selectedId: eventsPileCards[0].id,
+      })
+  ),
+  on(EventsPileCardsActions.selectFirstEventsPileCard, (state) => ({
     ...state,
-    errorMsg: error,
+    selectedId: state.ids[0] as string,
   })),
-  on(EventsPileCardsActions.selectEventsPileCard, (state, { id }) => ({
-    ...state,
-    selectedId: id,
-  })),
-  on(EventsPileCardsActions.unselectEventsPileCard, (state) => ({
-    ...state,
-    selectedId: undefined,
-  })),
-  on(EventsPileCardsActions.removeEventsPileCard, (state, { id }) =>
-    eventsPileCardsAdapter.removeOne(id, state)
-  )
+  on(EventsPileCardsActions.removeSelectedEventsPileCard, (state) => {
+    const unselectedState = {
+      ...state,
+      selectedId: undefined,
+    };
+    if (state.selectedId !== undefined) {
+      return eventsPileCardsAdapter.removeOne(
+        state.selectedId,
+        unselectedState
+      );
+    } else {
+      return unselectedState;
+    }
+  })
 );

--- a/libs/data-access-game/src/lib/+state/game/game.actions.ts
+++ b/libs/data-access-game/src/lib/+state/game/game.actions.ts
@@ -25,7 +25,7 @@ export const throwProductionDie = createAction(
 export const throwEventDie = createAction('[Dice Component] Throw Event Die');
 export const setProductionDie = createAction(
   '[Dice] Set Production Die',
-  props<{ value: ResourceValue }>()
+  props<{ value: ResourceValue | undefined }>()
 );
 export const setNextProductionDie = createAction(
   '[Dice] Set Next Production Die',
@@ -33,5 +33,5 @@ export const setNextProductionDie = createAction(
 );
 export const setEventDie = createAction(
   '[Dice] Set Event Die',
-  props<{ value: EventValue }>()
+  props<{ value: EventValue | undefined }>()
 );

--- a/libs/data-access-game/src/lib/+state/game/game.effects.spec.ts
+++ b/libs/data-access-game/src/lib/+state/game/game.effects.spec.ts
@@ -75,13 +75,14 @@ describe('GameEffects', () => {
       });
 
       it(`should dispatch setProductionDie
-          with nextProductionDie value
+          with undefined then nextProductionDie value
           and reset nextProductionDie`, () => {
-        actions = hot('-a----|', { a: GameActions.throwProductionDie() });
+        actions = hot('-a-----|', { a: GameActions.throwProductionDie() });
 
-        const expected = hot('-(ab)-|', {
-          a: GameActions.setProductionDie({ value: 3 }),
-          b: GameActions.setNextProductionDie({ value: undefined }),
+        const expected = hot('-(abc)-|', {
+          a: GameActions.setProductionDie({ value: undefined }),
+          b: GameActions.setProductionDie({ value: 3 }),
+          c: GameActions.setNextProductionDie({ value: undefined }),
         });
 
         expect(effects.throwProduction$).toBeObservable(expected);
@@ -106,12 +107,14 @@ describe('GameEffects', () => {
       });
 
       it(`should dispatch setProductionDie
-          with random value, and reset nextProductionDie`, () => {
-        actions = hot('-a----|', { a: GameActions.throwProductionDie() });
+          with undefined then mocked random value
+          and reset nextProductionDie`, () => {
+        actions = hot('-a-----|', { a: GameActions.throwProductionDie() });
 
-        const expected = hot('-(ab)-|', {
-          a: GameActions.setProductionDie({ value: 1 }),
-          b: GameActions.setNextProductionDie({ value: undefined }),
+        const expected = hot('-(abc)-|', {
+          a: GameActions.setProductionDie({ value: undefined }),
+          b: GameActions.setProductionDie({ value: 1 }),
+          c: GameActions.setNextProductionDie({ value: undefined }),
         });
 
         expect(effects.throwProduction$).toBeObservable(expected);
@@ -120,11 +123,12 @@ describe('GameEffects', () => {
   });
 
   describe('throwEvent$', () => {
-    it('should dispatch setEventDie', () => {
-      actions = hot('-a-|', { a: GameActions.throwEventDie() });
+    it('should dispatch setEventDie with undefined then mocked random value', () => {
+      actions = hot('-a----|', { a: GameActions.throwEventDie() });
 
-      const expected = hot('-a-|', {
-        a: GameActions.setEventDie({ value: EventValue.Event }),
+      const expected = hot('-(ab)-|', {
+        a: GameActions.setEventDie({ value: undefined }),
+        b: GameActions.setEventDie({ value: EventValue.Event }),
       });
 
       expect(effects.throwEvent$).toBeObservable(expected);

--- a/libs/data-access-game/src/lib/+state/game/game.effects.ts
+++ b/libs/data-access-game/src/lib/+state/game/game.effects.ts
@@ -38,6 +38,8 @@ export class GameEffects {
         }
       }),
       switchMap((value) => [
+        // Set undefined to force a change if same value as previous
+        GameActions.setProductionDie({ value: undefined }),
         GameActions.setProductionDie({ value }),
         GameActions.setNextProductionDie({ value: undefined }),
       ])
@@ -48,7 +50,11 @@ export class GameEffects {
     this.actions$.pipe(
       ofType(GameActions.throwEventDie),
       map(() => getRandomEventDieValue()),
-      map((value) => GameActions.setEventDie({ value }))
+      switchMap((value) => [
+        // Set undefined to force a change if same value as previous
+        GameActions.setEventDie({ value: undefined }),
+        GameActions.setEventDie({ value }),
+      ])
     )
   );
 

--- a/libs/data-access-game/src/test/fixtures/domains-cards.ts
+++ b/libs/data-access-game/src/test/fixtures/domains-cards.ts
@@ -7,7 +7,7 @@ import {
 } from '../../lib/+state/domains-cards/domains-cards.models';
 import { DomainsCardsState } from '../../lib/+state/domains-cards/domains-cards.reducer';
 
-export const someId = '7a1e11aa-47bb-4b4e-94ab-4c91c19e6a62';
+export const someDomainsCardsId = '7a1e11aa-47bb-4b4e-94ab-4c91c19e6a62';
 export const redClayPitId = '9ed2d3b8-1d98-4331-969e-09b7f1ba046e';
 export const blueForestId = 'fb675e2e-ee40-4e07-b29c-d6dbd823ca53';
 const nextToRedClayPit = '444bebc9-2521-49f0-b790-2668a4baa182';
@@ -57,7 +57,7 @@ export const aaaaWarehouseNextToBlueForestDomainCard: DomainsCardsEntity = creat
 );
 
 const domainsCardsNewGameStateIds = [
-  someId,
+  someDomainsCardsId,
   '8641399b-c626-4e64-8b66-5ea20e580690',
   '283dc5b6-bcef-4050-b6f7-63bfd8df5442',
   '537144b6-b0ca-4e7e-885c-9d6aa2056a72',
@@ -90,8 +90,8 @@ const domainsCardsNewGameStateIds = [
 ];
 
 export const domainsCardsNewGameStateEntities = {
-  [someId]: {
-    id: someId,
+  [someDomainsCardsId]: {
+    id: someDomainsCardsId,
     domainId: 'DOMAIN_RED',
     cardType: 'AgglomerationCard',
     cardId: 'ROAD_RED',

--- a/libs/data-access-game/src/test/fixtures/events-pile-cards.ts
+++ b/libs/data-access-game/src/test/fixtures/events-pile-cards.ts
@@ -1,0 +1,85 @@
+import { EventsPileCardsEntity } from '../../lib/+state/events-pile-cards/events-pile-cards.models';
+import { EventsPileCardsState } from '../../lib/+state/events-pile-cards/events-pile-cards.reducer';
+
+export const someEventsPileCardsId = '9e151a39-1957-4a94-bf36-de2d724fccda';
+
+export const eventsPileCardsNewGameStateIds = [
+  someEventsPileCardsId,
+  'd30e9625-674f-4d41-91f9-a2b5038cfaef',
+  '895ff4bf-7fee-4f86-8216-30e0d834553d',
+  '98d61ae1-f343-4400-992c-27405e6bc8ce',
+  '50f72d2c-50d2-4acd-9804-5073fef2046a',
+  '32cdcb57-a861-41a1-9ba3-6c62786a58fb',
+  '57735cc9-fead-44bd-8309-b949c786eaaa',
+  '57204c1f-5009-4ea3-bd90-a97433cec47c',
+  '23213a21-f9ab-48fe-bb4f-cb08ea8761f7',
+];
+
+export const eventsPileCardsNewGameStateEntities = {
+  [someEventsPileCardsId]: {
+    id: someEventsPileCardsId,
+    cardId: 'EVENT_1',
+  } as EventsPileCardsEntity,
+  'd30e9625-674f-4d41-91f9-a2b5038cfaef': {
+    id: 'd30e9625-674f-4d41-91f9-a2b5038cfaef',
+    cardId: 'EVENT_3',
+  } as EventsPileCardsEntity,
+  '895ff4bf-7fee-4f86-8216-30e0d834553d': {
+    id: '895ff4bf-7fee-4f86-8216-30e0d834553d',
+    cardId: 'EVENT_8',
+  } as EventsPileCardsEntity,
+  '98d61ae1-f343-4400-992c-27405e6bc8ce': {
+    id: '98d61ae1-f343-4400-992c-27405e6bc8ce',
+    cardId: 'EVENT_7',
+  } as EventsPileCardsEntity,
+  '50f72d2c-50d2-4acd-9804-5073fef2046a': {
+    id: '50f72d2c-50d2-4acd-9804-5073fef2046a',
+    cardId: 'EVENT_2',
+  } as EventsPileCardsEntity,
+  '32cdcb57-a861-41a1-9ba3-6c62786a58fb': {
+    id: '32cdcb57-a861-41a1-9ba3-6c62786a58fb',
+    cardId: 'EVENT_0',
+  } as EventsPileCardsEntity,
+  '57735cc9-fead-44bd-8309-b949c786eaaa': {
+    id: '57735cc9-fead-44bd-8309-b949c786eaaa',
+    cardId: 'EVENT_5',
+  } as EventsPileCardsEntity,
+  '57204c1f-5009-4ea3-bd90-a97433cec47c': {
+    id: '57204c1f-5009-4ea3-bd90-a97433cec47c',
+    cardId: 'EVENT_6',
+  } as EventsPileCardsEntity,
+  '23213a21-f9ab-48fe-bb4f-cb08ea8761f7': {
+    id: '23213a21-f9ab-48fe-bb4f-cb08ea8761f7',
+    cardId: 'EVENT_4',
+  } as EventsPileCardsEntity,
+};
+
+export const eventsPileCardsNewGameState: EventsPileCardsState = {
+  ids: eventsPileCardsNewGameStateIds,
+  entities: eventsPileCardsNewGameStateEntities,
+  initialized: true,
+  loaded: false,
+};
+
+export const eventsPileCardsSelectedState = (): EventsPileCardsState => {
+  const domainsCards = {
+    ...eventsPileCardsNewGameState,
+    selectedId: someEventsPileCardsId,
+  };
+  return domainsCards;
+};
+
+export const eventsPileCardsRemovedSelectedState = (): EventsPileCardsState => {
+  const newIds = (eventsPileCardsNewGameState.ids as string[]).filter(
+    (id) => id !== someEventsPileCardsId
+  );
+  const newEntities = { ...eventsPileCardsNewGameState.entities };
+  delete newEntities[someEventsPileCardsId];
+
+  const domainsCards = {
+    ...eventsPileCardsNewGameState,
+    ids: newIds,
+    entities: newEntities,
+  };
+  return domainsCards;
+};

--- a/libs/data-access-game/src/test/index.ts
+++ b/libs/data-access-game/src/test/index.ts
@@ -1,1 +1,2 @@
 export * from './fixtures/domains-cards';
+export * from './fixtures/events-pile-cards';

--- a/libs/feature-engine/src/lib/game-rules.service.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.ts
@@ -63,6 +63,11 @@ export class GameRulesService {
     )
   );
 
+  festival$ = this.eventsPileCards.selectedEventsPileCards$.pipe(
+    filter((pivot): pivot is EventsPileCardsEntity => pivot !== undefined),
+    filter((pivot) => eventCards.get(pivot.cardId)?.name === EventName.Festival)
+  );
+
   increaseResourcesForDie$ = this.game.productionDie$.pipe(
     takeUntil(this.gameEnded$),
     filter((value): value is DiceValue => value !== undefined),
@@ -72,6 +77,11 @@ export class GameRulesService {
   increaseResourcesForAuspiciousYear$ = this.auspiciousYear$.pipe(
     takeUntil(this.gameEnded$),
     map(() => this.domainsCards.increaseResourcesForAuspiciousYear())
+  );
+
+  resetEventsPileOnFestival$ = this.festival$.pipe(
+    takeUntil(this.gameEnded$),
+    map(() => this.eventsPileCards.resetEventsPile())
   );
 
   constructor(
@@ -90,6 +100,7 @@ export class GameRulesService {
     this.selectFirstEvent$.subscribe();
     this.increaseResourcesForDie$.subscribe();
     this.increaseResourcesForAuspiciousYear$.subscribe();
+    this.resetEventsPileOnFestival$.subscribe();
 
     this.game.initNewGame();
     this.domainsCards.initNewGame();


### PR DESCRIPTION
### Description
Add an observable for the festival event.
Add actions and reducer to reset events pile.
Move some simple effects to reducer.
Fix same events dispatch in a row not passed down the selectors.
Fix selectedId unset on init.

https://lhbruneton.atlassian.net/browse/TAOR-36

### Checklist
- [x] Created tests with given/when/then blocks
- [x] Created tests for the nominal use case
- [ ] Created tests for errors
- [x] Build project without errors
