### PR TITLE
TAOR-50: Put hand card on top of discard pile

### DIFF
--- a/apps/taormina-duel/src/app/app.component.html
+++ b/apps/taormina-duel/src/app/app.component.html
@@ -142,6 +142,7 @@
     <p>Remaining: {{ getFaceUpPileCount(pile) | async }}</p>
   </div>
   <div>
+    LANDS PILE
     <div *ngFor="let pivot of getLandsPileCards() | async; index as i">
       <div *ngIf="getLandCard(pivot.cardId) as land">
         {{ land.type }} - {{ land.die }}
@@ -155,7 +156,8 @@
       </div>
     </div>
   </div>
-  <div *ngFor="let pile of getStockPiles()">
+  <div *ngFor="let pile of getStockPiles(); index as i">
+    STOCK PILE {{ i }}
     <button
       *ngIf="drawInitialRedHandAvailable() | async"
       type="button"
@@ -208,6 +210,7 @@
     </button>
   </div>
   <div>
+    EVENTS PILE
     <div *ngFor="let pivot of getEventsPileCards() | async">
       <div *ngIf="getEventCard(pivot.cardId) as event">
         {{ event.name }}

--- a/apps/taormina-duel/src/app/app.component.html
+++ b/apps/taormina-duel/src/app/app.component.html
@@ -217,6 +217,31 @@
       </div>
     </div>
   </div>
+  <div>
+    DISCARD PILE
+    <div
+      *ngFor="let pivot of getDiscardPileCardsReverse() | async"
+      [ngSwitch]="pivot.cardType"
+    >
+      <div *ngSwitchCase="ACTION_CARD_INTERFACE_NAME">
+        <div *ngIf="getActionCard(pivot.cardId) as action">
+          {{ action.name }}
+        </div>
+      </div>
+      <div *ngSwitchCase="DEVELOPMENT_CARD_INTERFACE_NAME">
+        <div *ngIf="getDevelopmentCard(pivot.cardId) as development">
+          {{ development.name }}
+        </div>
+      </div>
+    </div>
+    <button
+      *ngIf="putSelectedHandCardToDiscardPileAvailable() | async"
+      type="button"
+      (click)="putSelectedHandCardToDiscardPile()"
+    >
+      Put selected hand card on top
+    </button>
+  </div>
 </div>
 <hr />
 <div *ngIf="getRedHand() as hand">

--- a/apps/taormina-duel/src/app/app.component.spec.ts
+++ b/apps/taormina-duel/src/app/app.component.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { StoreModule } from '@ngrx/store';
 import {
+  DiscardPileCardsFacade,
   DomainsCardsFacade,
   EventsPileCardsFacade,
   FaceUpPilesCardsFacade,
@@ -26,6 +27,7 @@ describe('AppComponent', () => {
         LandsPileCardsFacade,
         StockPilesCardsFacade,
         EventsPileCardsFacade,
+        DiscardPileCardsFacade,
         GameRulesService,
       ],
     }).compileComponents();

--- a/apps/taormina-duel/src/app/app.component.ts
+++ b/apps/taormina-duel/src/app/app.component.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
 import {
+  DiscardPileCardsEntity,
+  DiscardPileCardsFacade,
   DomainsCardsEntity,
   DomainsCardsFacade,
   EventsPileCardsEntity,
@@ -85,6 +87,7 @@ export class AppComponent {
     private landsPileCards: LandsPileCardsFacade,
     private stockPilesCards: StockPilesCardsFacade,
     private eventsPileCards: EventsPileCardsFacade,
+    private discardPileCards: DiscardPileCardsFacade,
     private gameRules: GameRulesService
   ) {}
 
@@ -284,6 +287,22 @@ export class AppComponent {
 
   getEventCard(cardId: string): EventCard | undefined {
     return eventCards.get(cardId);
+  }
+
+  getDiscardPileCardsReverse(): Observable<DiscardPileCardsEntity[]> {
+    return this.discardPileCards.allDiscardPileCardsReverse$;
+  }
+
+  putSelectedHandCardToDiscardPileAvailable(): Observable<boolean> {
+    return this.game.phase$.pipe(
+      map((phase) => {
+        return phase === GamePhase.LoopActions;
+      })
+    );
+  }
+
+  putSelectedHandCardToDiscardPile(): void {
+    this.gameRules.putFromHandToDiscardPile();
   }
 
   getRedHand(): Hand | undefined {

--- a/apps/taormina-duel/src/app/app.component.ts
+++ b/apps/taormina-duel/src/app/app.component.ts
@@ -365,7 +365,7 @@ export class AppComponent {
   }
 
   putBackSelectedHandCard(pileId: string): void {
-    this.gameRules.putBackFromHandToStock(pileId);
+    this.gameRules.putBackFromHandToStockPile(pileId);
   }
 
   getActionCard(cardId: string): ActionCard | undefined {

--- a/libs/data-access-game/src/index.ts
+++ b/libs/data-access-game/src/index.ts
@@ -1,5 +1,6 @@
 export * from './lib/+state/discard-pile-cards/discard-pile-cards.actions';
 export * from './lib/+state/discard-pile-cards/discard-pile-cards.facade';
+export * from './lib/+state/discard-pile-cards/discard-pile-cards.models';
 export * from './lib/+state/discard-pile-cards/discard-pile-cards.reducer';
 export * from './lib/+state/discard-pile-cards/discard-pile-cards.selectors';
 export * from './lib/+state/domains-cards/domains-cards.actions';

--- a/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.actions.ts
+++ b/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.actions.ts
@@ -1,4 +1,8 @@
 import { createAction, props } from '@ngrx/store';
+import {
+  ACTION_CARD_INTERFACE_NAME,
+  DEVELOPMENT_CARD_INTERFACE_NAME,
+} from '@taormina/shared-models';
 import { DiscardPileCardsEntity } from './discard-pile-cards.models';
 
 export const initDiscardPileCardsNewGame = createAction(
@@ -27,4 +31,21 @@ export const setDiscardPileCardsInitialized = createAction(
 export const setDiscardPileCardsError = createAction(
   '[DiscardPileCards] Set DiscardPileCards Error',
   props<{ error: string }>()
+);
+
+export const addCardToDiscardPile = createAction(
+  '[DiscardPileCards] Add Card To Discard Pile',
+  props<{
+    card: {
+      type:
+        | typeof ACTION_CARD_INTERFACE_NAME
+        | typeof DEVELOPMENT_CARD_INTERFACE_NAME;
+      id: string;
+    };
+  }>()
+);
+
+export const addDiscardPileCard = createAction(
+  '[DiscardPileCards] Add DiscardPileCard',
+  props<{ discardPileCard: DiscardPileCardsEntity }>()
 );

--- a/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.effects.spec.ts
+++ b/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.effects.spec.ts
@@ -4,10 +4,18 @@ import { Action } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
 import { DataPersistence, NxModule } from '@nrwl/angular';
 import { hot } from '@nrwl/angular/testing';
+import { ACTION_CARD_INTERFACE_NAME } from '@taormina/shared-models';
 import { Observable } from 'rxjs';
 
 import * as DiscardPileCardsActions from './discard-pile-cards.actions';
 import { DiscardPileCardsEffects } from './discard-pile-cards.effects';
+
+jest.mock('uuid', () => {
+  return {
+    __esModule: true,
+    v4: jest.fn(() => 'AAA'),
+  };
+});
 
 describe('DiscardPileCardsEffects', () => {
   let actions: Observable<Action>;
@@ -56,6 +64,28 @@ describe('DiscardPileCardsEffects', () => {
       });
 
       expect(effects.initSavedGame$).toBeObservable(expected);
+    });
+  });
+
+  describe('addCard$', () => {
+    it('should dispatch addDiscardPileCard', () => {
+      actions = hot('-a-|', {
+        a: DiscardPileCardsActions.addCardToDiscardPile({
+          card: { type: ACTION_CARD_INTERFACE_NAME, id: 'A' },
+        }),
+      });
+
+      const expected = hot('-a-|', {
+        a: DiscardPileCardsActions.addDiscardPileCard({
+          discardPileCard: {
+            id: 'AAA',
+            cardType: ACTION_CARD_INTERFACE_NAME,
+            cardId: 'A',
+          },
+        }),
+      });
+
+      expect(effects.addCard$).toBeObservable(expected);
     });
   });
 });

--- a/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.effects.ts
+++ b/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.effects.ts
@@ -2,8 +2,10 @@ import { Injectable } from '@angular/core';
 import { createEffect, Actions, ofType } from '@ngrx/effects';
 import { fetch } from '@nrwl/angular';
 import { map } from 'rxjs/operators';
+import { v4 as uuidv4 } from 'uuid';
 
 import * as DiscardPileCardsActions from './discard-pile-cards.actions';
+import { createDiscardPileCardsEntity } from './discard-pile-cards.models';
 
 @Injectable()
 export class DiscardPileCardsEffects {
@@ -34,6 +36,18 @@ export class DiscardPileCardsEffects {
           return DiscardPileCardsActions.loadDiscardPileCardsFailure({ error });
         },
       })
+    )
+  );
+
+  addCard$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(DiscardPileCardsActions.addCardToDiscardPile),
+      map(({ card }) =>
+        createDiscardPileCardsEntity(uuidv4(), card.type, card.id)
+      ),
+      map((discardPileCard) =>
+        DiscardPileCardsActions.addDiscardPileCard({ discardPileCard })
+      )
     )
   );
 

--- a/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.facade.ts
+++ b/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.facade.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@angular/core';
 import { select, Store } from '@ngrx/store';
+import {
+  ACTION_CARD_INTERFACE_NAME,
+  DEVELOPMENT_CARD_INTERFACE_NAME,
+} from '@taormina/shared-models';
 
 import * as DiscardPileCardsActions from './discard-pile-cards.actions';
 import * as DiscardPileCardsFeature from './discard-pile-cards.reducer';
@@ -16,6 +20,9 @@ export class DiscardPileCardsFacade {
   );
   allDiscardPileCards$ = this.store.pipe(
     select(DiscardPileCardsSelectors.getAllDiscardPileCards)
+  );
+  allDiscardPileCardsReverse$ = this.store.pipe(
+    select(DiscardPileCardsSelectors.getAllDiscardPileCardsReverse)
   );
   selectedDiscardPileCards$ = this.store.pipe(
     select(DiscardPileCardsSelectors.getDiscardPileCardsSelected)
@@ -37,5 +44,14 @@ export class DiscardPileCardsFacade {
     this.store.dispatch(
       DiscardPileCardsActions.initDiscardPileCardsSavedGame()
     );
+  }
+
+  addCardToDiscardPile(card: {
+    type:
+      | typeof ACTION_CARD_INTERFACE_NAME
+      | typeof DEVELOPMENT_CARD_INTERFACE_NAME;
+    id: string;
+  }): void {
+    this.store.dispatch(DiscardPileCardsActions.addCardToDiscardPile({ card }));
   }
 }

--- a/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.reducer.spec.ts
+++ b/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.reducer.spec.ts
@@ -1,4 +1,11 @@
 import { Action } from '@ngrx/store';
+
+import {
+  discardPileCardsMinusLastCardState,
+  discardPileCardsState,
+  discardPileCardsStateEntities,
+  someDiscardPileCardsId,
+} from '../../../test';
 import * as DiscardPileCardsActions from './discard-pile-cards.actions';
 import { createDiscardPileCardsEntity } from './discard-pile-cards.models';
 import {
@@ -57,6 +64,21 @@ describe('DiscardPileCards Reducer', () => {
       );
 
       expect(state).toEqual(newState);
+    });
+  });
+
+  describe('addDiscardPileCard', () => {
+    it('should add StockPilesCards to the list', () => {
+      const action = DiscardPileCardsActions.addDiscardPileCard({
+        discardPileCard: discardPileCardsStateEntities[someDiscardPileCardsId],
+      });
+
+      const state: DiscardPileCardsState = discardPileCardsReducer(
+        discardPileCardsMinusLastCardState(),
+        action
+      );
+
+      expect(state).toEqual(discardPileCardsState);
     });
   });
 

--- a/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.reducer.ts
+++ b/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.reducer.ts
@@ -19,15 +19,15 @@ export interface DiscardPileCardsPartialState {
 }
 
 // eslint-disable-next-line max-len
-export const discardPileCardsAdapter: EntityAdapter<DiscardPileCardsEntity> = createEntityAdapter<DiscardPileCardsEntity>();
+export const discardPileCardsAdapter: EntityAdapter<DiscardPileCardsEntity> =
+  createEntityAdapter<DiscardPileCardsEntity>();
 
-export const initialDiscardPileCardsState: DiscardPileCardsState = discardPileCardsAdapter.getInitialState(
-  {
+export const initialDiscardPileCardsState: DiscardPileCardsState =
+  discardPileCardsAdapter.getInitialState({
     // set initial required properties
     initialized: false,
     loaded: false,
-  }
-);
+  });
 
 export const discardPileCardsReducer = createReducer(
   initialDiscardPileCardsState,

--- a/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.reducer.ts
+++ b/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.reducer.ts
@@ -60,6 +60,9 @@ export const discardPileCardsReducer = createReducer(
         initialized: true,
       })
   ),
+  on(DiscardPileCardsActions.addDiscardPileCard, (state, { discardPileCard }) =>
+    discardPileCardsAdapter.addOne(discardPileCard, state)
+  ),
   on(DiscardPileCardsActions.setDiscardPileCardsError, (state, { error }) => ({
     ...state,
     errorMsg: error,

--- a/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.selectors.spec.ts
@@ -42,10 +42,29 @@ describe('DiscardPileCards Selectors', () => {
   describe('getAllDiscardPileCards()', () => {
     it('should return the list of DiscardPileCards', () => {
       const results = DiscardPileCardsSelectors.getAllDiscardPileCards(state);
-      const selId = getDiscardPileCardsId(results[1]);
+      const id0 = getDiscardPileCardsId(results[0]);
+      const id1 = getDiscardPileCardsId(results[1]);
+      const id2 = getDiscardPileCardsId(results[2]);
 
       expect(results.length).toBe(3);
-      expect(selId).toBe('PRODUCT-BBB');
+      expect(id0).toBe('PRODUCT-AAA');
+      expect(id1).toBe('PRODUCT-BBB');
+      expect(id2).toBe('PRODUCT-CCC');
+    });
+  });
+
+  describe('getAllDiscardPileCardsReverse()', () => {
+    it('should return the reversed list of DiscardPileCards', () => {
+      const results =
+        DiscardPileCardsSelectors.getAllDiscardPileCardsReverse(state);
+      const id0 = getDiscardPileCardsId(results[0]);
+      const id1 = getDiscardPileCardsId(results[1]);
+      const id2 = getDiscardPileCardsId(results[2]);
+
+      expect(results.length).toBe(3);
+      expect(id0).toBe('PRODUCT-CCC');
+      expect(id1).toBe('PRODUCT-BBB');
+      expect(id2).toBe('PRODUCT-AAA');
     });
   });
 

--- a/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.selectors.spec.ts
@@ -51,9 +51,8 @@ describe('DiscardPileCards Selectors', () => {
 
   describe('getDiscardPileCardsSelected()', () => {
     it('should return the selected Entity', () => {
-      const result = DiscardPileCardsSelectors.getDiscardPileCardsSelected(
-        state
-      );
+      const result =
+        DiscardPileCardsSelectors.getDiscardPileCardsSelected(state);
       const selId = getDiscardPileCardsId(result);
 
       expect(selId).toBe('PRODUCT-BBB');

--- a/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.selectors.ts
@@ -29,6 +29,11 @@ export const getAllDiscardPileCards = createSelector(
   (state: DiscardPileCardsState) => selectAll(state)
 );
 
+export const getAllDiscardPileCardsReverse = createSelector(
+  getDiscardPileCardsState,
+  (state: DiscardPileCardsState) => [...selectAll(state)].reverse()
+);
+
 export const getDiscardPileCardsEntities = createSelector(
   getDiscardPileCardsState,
   (state: DiscardPileCardsState) => selectEntities(state)

--- a/libs/data-access-game/src/test/fixtures/discard-pile-cards.ts
+++ b/libs/data-access-game/src/test/fixtures/discard-pile-cards.ts
@@ -1,0 +1,50 @@
+import { DiscardPileCardsEntity } from '../../lib/+state/discard-pile-cards/discard-pile-cards.models';
+import { DiscardPileCardsState } from '../../lib/+state/discard-pile-cards/discard-pile-cards.reducer';
+
+export const someDiscardPileCardsId = '84419fe2-5d79-4f2b-8431-75fbdd1dcddf';
+
+const discardPileCardsStateIds = [
+  'ff23799c-e214-414d-ac23-2be1b9f27d35',
+  '895c8c83-0649-4bf2-b7dc-6e7e2220c121',
+  someDiscardPileCardsId,
+];
+
+export const discardPileCardsStateEntities = {
+  'ff23799c-e214-414d-ac23-2be1b9f27d35': {
+    id: 'ff23799c-e214-414d-ac23-2be1b9f27d35',
+    cardType: 'ActionCard',
+    cardId: 'ACTION_8',
+  } as DiscardPileCardsEntity,
+  '895c8c83-0649-4bf2-b7dc-6e7e2220c121': {
+    id: '895c8c83-0649-4bf2-b7dc-6e7e2220c121',
+    cardType: 'ActionCard',
+    cardId: 'ACTION_4',
+  } as DiscardPileCardsEntity,
+  [someDiscardPileCardsId]: {
+    id: someDiscardPileCardsId,
+    cardType: 'ActionCard',
+    cardId: 'ACTION_6',
+  } as DiscardPileCardsEntity,
+};
+
+export const discardPileCardsState: DiscardPileCardsState = {
+  ids: discardPileCardsStateIds,
+  entities: discardPileCardsStateEntities,
+  initialized: true,
+  loaded: false,
+};
+
+export const discardPileCardsMinusLastCardState = (): DiscardPileCardsState => {
+  const newIds = (discardPileCardsState.ids as string[]).filter(
+    (id) => id !== someDiscardPileCardsId
+  );
+  const newEntities = { ...discardPileCardsState.entities };
+  delete newEntities[someDiscardPileCardsId];
+
+  const stockPilesCards = {
+    ...discardPileCardsState,
+    ids: newIds,
+    entities: newEntities,
+  };
+  return stockPilesCards;
+};

--- a/libs/data-access-game/src/test/index.ts
+++ b/libs/data-access-game/src/test/index.ts
@@ -1,3 +1,4 @@
+export * from './fixtures/discard-pile-cards';
 export * from './fixtures/domains-cards';
 export * from './fixtures/events-pile-cards';
 export * from './fixtures/hands-cards';

--- a/libs/feature-engine/src/lib/game-rules.service.spec.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.spec.ts
@@ -1215,7 +1215,7 @@ describe('GameRulesService', () => {
     });
   });
 
-  describe('putBackFromHandToStock', () => {
+  describe('putBackFromHandToStockPile', () => {
     describe('OK', () => {
       const handsCardsFacadeMock = {
         selectedHandsCards$: of({
@@ -1246,8 +1246,8 @@ describe('GameRulesService', () => {
       });
 
       it(`should call removeHandCard and unselectHandCard,
-        then addCardsToStockPileBottom`, () => {
-        service.putBackFromHandToStock('STOCK_1');
+          then addCardsToStockPileBottom`, () => {
+        service.putBackFromHandToStockPile('STOCK_1');
 
         expect(handsCardsFacadeMock.removeHandCard).toHaveBeenCalledWith(
           'aaaa'
@@ -1290,7 +1290,7 @@ describe('GameRulesService', () => {
 
       // FIXME: should test error thrown
       it('should not call', () => {
-        service.putBackFromHandToStock('STOCK_1');
+        service.putBackFromHandToStockPile('STOCK_1');
 
         expect(handsCardsFacadeMock.removeHandCard).not.toHaveBeenCalled();
         expect(handsCardsFacadeMock.unselectHandCard).not.toHaveBeenCalled();

--- a/libs/feature-engine/src/lib/game-rules.service.spec.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.spec.ts
@@ -2,6 +2,7 @@
 import { inject, TestBed } from '@angular/core/testing';
 import { StoreModule } from '@ngrx/store';
 import {
+  DiscardPileCardsFacade,
   DomainsCardsFacade,
   EventsPileCardsFacade,
   FaceUpPilesCardsFacade,
@@ -48,6 +49,7 @@ describe('GameRulesService', () => {
         LandsPileCardsFacade,
         StockPilesCardsFacade,
         EventsPileCardsFacade,
+        DiscardPileCardsFacade,
       ],
     });
   });
@@ -411,6 +413,9 @@ describe('GameRulesService', () => {
       selectedEventsPileCards$: of(),
       initNewGame: jest.fn(),
     };
+    const discardPileCardsFacadeMock = {
+      initNewGame: jest.fn(),
+    };
 
     beforeEach(() => {
       TestBed.configureTestingModule({
@@ -430,6 +435,10 @@ describe('GameRulesService', () => {
           {
             provide: EventsPileCardsFacade,
             useValue: eventsPileCardsFacadeMock,
+          },
+          {
+            provide: DiscardPileCardsFacade,
+            useValue: discardPileCardsFacadeMock,
           },
         ],
       });
@@ -477,6 +486,7 @@ describe('GameRulesService', () => {
       expect(landsPileCardsFacadeMock.initNewGame).toHaveBeenCalledTimes(1);
       expect(stockPilesCardsFacadeMock.initNewGame).toHaveBeenCalledTimes(1);
       expect(eventsPileCardsFacadeMock.initNewGame).toHaveBeenCalledTimes(1);
+      expect(discardPileCardsFacadeMock.initNewGame).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/libs/feature-engine/src/lib/game-rules.service.spec.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.spec.ts
@@ -20,6 +20,7 @@ import {
   ID_HAND_RED,
 } from '@taormina/shared-constants';
 import {
+  ACTION_CARD_INTERFACE_NAME,
   AGGLOMERATION_CARD_INTERFACE_NAME,
   AVAILABLE_AGGLOMERATION_SLOT,
   AVAILABLE_DEVELOPMENT_SLOT,
@@ -1306,6 +1307,90 @@ describe('GameRulesService', () => {
         expect(handsCardsFacadeMock.unselectHandCard).not.toHaveBeenCalled();
         expect(
           stockPilesCardsFacadeMock.addCardsToStockPileBottom
+        ).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('putFromHandToDiscardPile', () => {
+    describe('OK', () => {
+      const handsCardsFacadeMock = {
+        selectedHandsCards$: of({
+          id: 'aaaa',
+          handId: ID_HAND_BLUE,
+          cardType: ACTION_CARD_INTERFACE_NAME,
+          cardId: 'ACTION_1',
+        }),
+        removeHandCard: jest.fn(),
+        unselectHandCard: jest.fn(),
+      };
+      const discardPileCardsFacadeMock = {
+        addCardToDiscardPile: jest.fn(),
+      };
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [StoreModule.forRoot({})],
+          providers: [
+            { provide: HandsCardsFacade, useValue: handsCardsFacadeMock },
+            {
+              provide: DiscardPileCardsFacade,
+              useValue: discardPileCardsFacadeMock,
+            },
+          ],
+        });
+        service = TestBed.inject(GameRulesService);
+      });
+
+      it(`should call removeHandCard and unselectHandCard,
+          then addCardToDiscardPile`, () => {
+        service.putFromHandToDiscardPile();
+
+        expect(handsCardsFacadeMock.removeHandCard).toHaveBeenCalledWith(
+          'aaaa'
+        );
+        expect(handsCardsFacadeMock.unselectHandCard).toHaveBeenCalledTimes(1);
+        expect(
+          discardPileCardsFacadeMock.addCardToDiscardPile
+        ).toHaveBeenCalledWith({
+          type: ACTION_CARD_INTERFACE_NAME,
+          id: 'ACTION_1',
+        });
+      });
+    });
+
+    describe('NOK undefined selectedHandsCards', () => {
+      const handsCardsFacadeMock = {
+        selectedHandsCards$: of(undefined),
+        removeHandCard: jest.fn(),
+        unselectHandCard: jest.fn(),
+      };
+      const discardPileCardsFacadeMock = {
+        addCardToDiscardPile: jest.fn(),
+      };
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [StoreModule.forRoot({})],
+          providers: [
+            { provide: HandsCardsFacade, useValue: handsCardsFacadeMock },
+            {
+              provide: DiscardPileCardsFacade,
+              useValue: discardPileCardsFacadeMock,
+            },
+          ],
+        });
+        service = TestBed.inject(GameRulesService);
+      });
+
+      // FIXME: should test error thrown
+      it('should not call', () => {
+        service.putFromHandToDiscardPile();
+
+        expect(handsCardsFacadeMock.removeHandCard).not.toHaveBeenCalled();
+        expect(handsCardsFacadeMock.unselectHandCard).not.toHaveBeenCalled();
+        expect(
+          discardPileCardsFacadeMock.addCardToDiscardPile
         ).not.toHaveBeenCalled();
       });
     });

--- a/libs/feature-engine/src/lib/game-rules.service.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.ts
@@ -270,7 +270,7 @@ export class GameRulesService {
       .subscribe();
   }
 
-  putBackFromHandToStock(pileId: string): void {
+  putBackFromHandToStockPile(pileId: string): void {
     this.handsCards.selectedHandsCards$
       .pipe(
         take(1),

--- a/libs/feature-engine/src/lib/game-rules.service.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import {
+  DiscardPileCardsFacade,
   DomainsCardsFacade,
   EventsPileCardsEntity,
   EventsPileCardsFacade,
@@ -91,7 +92,8 @@ export class GameRulesService {
     private faceUpPilesCards: FaceUpPilesCardsFacade,
     private landsPileCards: LandsPileCardsFacade,
     private stockPilesCards: StockPilesCardsFacade,
-    private eventsPileCards: EventsPileCardsFacade
+    private eventsPileCards: EventsPileCardsFacade,
+    private discardPileCards: DiscardPileCardsFacade
   ) {}
 
   initNewGame(): void {
@@ -109,6 +111,7 @@ export class GameRulesService {
     this.landsPileCards.initNewGame();
     this.stockPilesCards.initNewGame();
     this.eventsPileCards.initNewGame();
+    this.discardPileCards.initNewGame();
   }
 
   drawFromStockToHand(

--- a/libs/feature-engine/src/lib/game-rules.service.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.ts
@@ -276,7 +276,7 @@ export class GameRulesService {
         take(1),
         map((handCard) => {
           if (handCard === undefined) {
-            throw new Error(`Can't put card in slot if no card selected.`);
+            throw new Error(`Can't put card in pile if no card selected.`);
           }
           this.handsCards.removeHandCard(handCard.id);
           this.handsCards.unselectHandCard();

--- a/libs/feature-engine/src/lib/game-rules.service.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.ts
@@ -293,4 +293,23 @@ export class GameRulesService {
       )
       .subscribe();
   }
+
+  putFromHandToDiscardPile(): void {
+    this.handsCards.selectedHandsCards$
+      .pipe(
+        take(1),
+        map((handCard) => {
+          if (handCard === undefined) {
+            throw new Error(`Can't put card in pile if no card selected.`);
+          }
+          this.handsCards.removeHandCard(handCard.id);
+          this.handsCards.unselectHandCard();
+          this.discardPileCards.addCardToDiscardPile({
+            type: handCard.cardType,
+            id: handCard.cardId,
+          });
+        })
+      )
+      .subscribe();
+  }
 }


### PR DESCRIPTION
### Description
Same as putting selected hand card to stock pile, except there is only one discard pile (no need for an id), and the discard pile is reversed.

https://lhbruneton.atlassian.net/browse/TAOR-50

### Checklist
- [ ] Created tests with given/when/then blocks
- [x] Created tests for the nominal use case
- [x] Created tests for errors
- [x] Build project without errors
