### PR TITLE
TAOR-16: Observe victory points

### DIFF
--- a/apps/taormina-duel/src/app/app.component.html
+++ b/apps/taormina-duel/src/app/app.component.html
@@ -272,6 +272,7 @@
     <span *ngIf="getStrengthMastery(domain.id) | async">
       - Strength Mastery</span
     >
+    <span> - Victory points: {{ getVictoryPoints(domain.id) | async }}</span>
   </div>
   <div
     class="grid-container"
@@ -357,6 +358,7 @@
     <span *ngIf="getStrengthMastery(domain.id) | async">
       - Strength Mastery</span
     >
+    <span> - Victory points: {{ getVictoryPoints(domain.id) | async }}</span>
   </div>
   <div
     class="grid-container"

--- a/apps/taormina-duel/src/app/app.component.ts
+++ b/apps/taormina-duel/src/app/app.component.ts
@@ -174,6 +174,10 @@ export class AppComponent {
       .pipe(map((masteryDomainId) => domainId === masteryDomainId));
   }
 
+  getVictoryPoints(domainId: string): Observable<number> {
+    return this.gameRules.getVictoryPointsForDomain(domainId);
+  }
+
   getColumnsTemplate(domainId: string): Observable<string> {
     return combineLatest([
       this.domainsCards.getDomainMinCol(domainId),

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.facade.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.facade.ts
@@ -149,4 +149,10 @@ export class DomainsCardsFacade {
       select(DomainsCardsSelectors.getMasteryDomainForType, { type })
     );
   }
+
+  getCardsVictoryPointsForDomain(domainId: string): Observable<number> {
+    return this.store.select(
+      DomainsCardsSelectors.getCardsVictoryPointsForDomain(domainId)
+    );
+  }
 }

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
@@ -423,4 +423,20 @@ describe('DomainsCards Selectors', () => {
       expect(cardIdGoldMineBlue).toBe(ID_GOLD_MINE_BLUE);
     });
   });
+
+  describe('getCardsVictoryPointsForDomain()', () => {
+    beforeEach(() => {
+      state = {
+        domainsCards: domainsCardsNewGameState,
+      };
+    });
+    it('should return two victory points for the two initial hamlets', () => {
+      const result =
+        DomainsCardsSelectors.getCardsVictoryPointsForDomain(ID_DOMAIN_RED)(
+          state
+        );
+
+      expect(result).toBe(2);
+    });
+  });
 });

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
@@ -127,9 +127,8 @@ describe('DomainsCards Selectors', () => {
       };
     });
     it('should return the red clay pit domain card', () => {
-      const results = DomainsCardsSelectors.getLandCardPivotWithLockedResources(
-        state
-      );
+      const results =
+        DomainsCardsSelectors.getLandCardPivotWithLockedResources(state);
       const selId = getDomainsCardsId(results[0]);
 
       expect(selId).toBe(redClayPitId);
@@ -185,12 +184,10 @@ describe('DomainsCards Selectors', () => {
 
     describe('getLandCardsPivotsIncreaseOneProduction({ die })', () => {
       it('should return the red clay pit for die 3', () => {
-        const results = DomainsCardsSelectors.getLandCardsPivotsIncreaseOneProduction(
-          state,
-          {
+        const results =
+          DomainsCardsSelectors.getLandCardsPivotsIncreaseOneProduction(state, {
             die: 3,
-          }
-        );
+          });
         const selId = getDomainsCardsId(results[0]);
 
         expect(selId).toBe(redClayPitId);
@@ -199,12 +196,10 @@ describe('DomainsCards Selectors', () => {
 
     describe('getLandCardsPivotsIncreaseTwoProduction({ die })', () => {
       it('should return the blue forest for die 3', () => {
-        const results = DomainsCardsSelectors.getLandCardsPivotsIncreaseTwoProduction(
-          state,
-          {
+        const results =
+          DomainsCardsSelectors.getLandCardsPivotsIncreaseTwoProduction(state, {
             die: 3,
-          }
-        );
+          });
         const selId = getDomainsCardsId(results[0]);
 
         expect(selId).toBe(blueForestId);
@@ -347,34 +342,31 @@ describe('DomainsCards Selectors', () => {
 
     describe('getDomainResourceCountSeenByThieves', () => {
       it('should return 5 resources seen by thieves for the red domain', () => {
-        const result = DomainsCardsSelectors.getDomainResourceCountSeenByThieves(
-          state,
-          {
+        const result =
+          DomainsCardsSelectors.getDomainResourceCountSeenByThieves(state, {
             domainId: ID_DOMAIN_RED,
-          }
-        );
+          });
         expect(result).toBe(5);
       });
 
       it('should return 4 resources seen by thieves for the blue domain', () => {
-        const result = DomainsCardsSelectors.getDomainResourceCountSeenByThieves(
-          state,
-          {
+        const result =
+          DomainsCardsSelectors.getDomainResourceCountSeenByThieves(state, {
             domainId: ID_DOMAIN_BLUE,
-          }
-        );
+          });
         expect(result).toBe(4);
       });
     });
 
     describe('getDomainUnprotectedGoldMinesAndPastures', () => {
       it('should return the gold mine and the pasture for the red domain', () => {
-        const results = DomainsCardsSelectors.getDomainUnprotectedGoldMinesAndPastures(
-          state,
-          {
-            domainId: ID_DOMAIN_RED,
-          }
-        );
+        const results =
+          DomainsCardsSelectors.getDomainUnprotectedGoldMinesAndPastures(
+            state,
+            {
+              domainId: ID_DOMAIN_RED,
+            }
+          );
         const cardIdGoldMineRed = results[0]?.cardId;
         const cardIdPastureRed = results[1]?.cardId;
 
@@ -384,12 +376,13 @@ describe('DomainsCards Selectors', () => {
       });
 
       it('should return only the pasture for the blue domain', () => {
-        const results = DomainsCardsSelectors.getDomainUnprotectedGoldMinesAndPastures(
-          state,
-          {
-            domainId: ID_DOMAIN_BLUE,
-          }
-        );
+        const results =
+          DomainsCardsSelectors.getDomainUnprotectedGoldMinesAndPastures(
+            state,
+            {
+              domainId: ID_DOMAIN_BLUE,
+            }
+          );
         const cardIdPastureBlue = results[0]?.cardId;
 
         expect(results.length).toBe(1);
@@ -405,12 +398,10 @@ describe('DomainsCards Selectors', () => {
       };
     });
     it('should return the clay pit and the pasture for the red domain with count 2', () => {
-      const results = DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear(
-        state,
-        {
+      const results =
+        DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear(state, {
           count: 2,
-        }
-      );
+        });
       const cardIdClayPitRed = results[0]?.cardId;
       const cardIdPastureRed = results[1]?.cardId;
 
@@ -420,12 +411,10 @@ describe('DomainsCards Selectors', () => {
     });
 
     it('should return the forest and the gold mine for the blue domain with count 1', () => {
-      const results = DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear(
-        state,
-        {
+      const results =
+        DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear(state, {
           count: 1,
-        }
-      );
+        });
       const cardIdForestBlue = results[0]?.cardId;
       const cardIdGoldMineBlue = results[1]?.cardId;
 

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
@@ -1,11 +1,14 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { createFeatureSelector, createSelector } from '@ngrx/store';
 import {
+  agglomerationCards,
   developmentCards,
   ID_DOMAIN_BLUE,
   ID_DOMAIN_RED,
   landCards,
 } from '@taormina/shared-constants';
 import {
+  AGGLOMERATION_CARD_INTERFACE_NAME,
   BuildingName,
   DevelopmentCard,
   DEVELOPMENT_CARD_INTERFACE_NAME,
@@ -360,3 +363,27 @@ const getCardSideNeighbors = (
       (domainCard.col === pivot.col - 1 || domainCard.col === pivot.col + 1) &&
       (pivot.row < 0 ? domainCard.row < 0 : domainCard.row >= 0)
   );
+
+export const getCardsVictoryPointsForDomain = (domainId: string) =>
+  createSelector(getAllDomainsCards, (entities) => {
+    return entities
+      .filter(
+        (domainCard) =>
+          domainCard.domainId === domainId && domainCard.cardId !== undefined
+      )
+      .map((domainCard) => {
+        switch (domainCard.cardType) {
+          case AGGLOMERATION_CARD_INTERFACE_NAME:
+            return (
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              agglomerationCards.get(domainCard.cardId!)?.victoryPoints || 0
+            );
+          case DEVELOPMENT_CARD_INTERFACE_NAME:
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            return developmentCards.get(domainCard.cardId!)?.victoryPoints || 0;
+          default:
+            return 0;
+        }
+      })
+      .reduce((accumulator, currentValue) => accumulator + currentValue, 0);
+  });

--- a/libs/feature-engine/src/lib/game-rules.service.spec.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.spec.ts
@@ -29,6 +29,7 @@ import {
   EventValue,
   GamePhase,
   LAND_CARD_INTERFACE_NAME,
+  MasteryPointsType,
 } from '@taormina/shared-models';
 import { of } from 'rxjs';
 import { marbles } from 'rxjs-marbles/jest';
@@ -1392,6 +1393,118 @@ describe('GameRulesService', () => {
         expect(
           discardPileCardsFacadeMock.addCardToDiscardPile
         ).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('getVictoryPointsForDomain', () => {
+    describe('no mastery', () => {
+      const domainsCardsFacadeMock = {
+        getCardsVictoryPointsForDomain: jest.fn(() => of(2)),
+        getMasteryDomainForType: jest.fn(() => of(undefined)),
+      };
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [StoreModule.forRoot({})],
+          providers: [
+            { provide: DomainsCardsFacade, useValue: domainsCardsFacadeMock },
+          ],
+        });
+        service = TestBed.inject(GameRulesService);
+      });
+
+      it(`should combine cards victory points
+          and neither trade nor strength victory points`, () => {
+        const victoryPoints$ = service.getVictoryPointsForDomain(ID_DOMAIN_RED);
+
+        victoryPoints$.subscribe((victoryPoints) => {
+          expect(victoryPoints).toEqual(2);
+        });
+      });
+    });
+
+    describe('trade mastery', () => {
+      const domainsCardsFacadeMock = {
+        getCardsVictoryPointsForDomain: jest.fn(() => of(2)),
+        getMasteryDomainForType: jest.fn((type) =>
+          type === MasteryPointsType.Trade ? of(ID_DOMAIN_RED) : of(undefined)
+        ),
+      };
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [StoreModule.forRoot({})],
+          providers: [
+            { provide: DomainsCardsFacade, useValue: domainsCardsFacadeMock },
+          ],
+        });
+        service = TestBed.inject(GameRulesService);
+      });
+
+      it(`should combine cards victory points
+          and trade but not strength victory points`, () => {
+        const victoryPoints$ = service.getVictoryPointsForDomain(ID_DOMAIN_RED);
+
+        victoryPoints$.subscribe((victoryPoints) => {
+          expect(victoryPoints).toEqual(3);
+        });
+      });
+    });
+
+    describe('strength mastery', () => {
+      const domainsCardsFacadeMock = {
+        getCardsVictoryPointsForDomain: jest.fn(() => of(2)),
+        getMasteryDomainForType: jest.fn((type) =>
+          type === MasteryPointsType.Strength
+            ? of(ID_DOMAIN_RED)
+            : of(undefined)
+        ),
+      };
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [StoreModule.forRoot({})],
+          providers: [
+            { provide: DomainsCardsFacade, useValue: domainsCardsFacadeMock },
+          ],
+        });
+        service = TestBed.inject(GameRulesService);
+      });
+
+      it(`should combine cards victory points
+          and not trade but strength victory points`, () => {
+        const victoryPoints$ = service.getVictoryPointsForDomain(ID_DOMAIN_RED);
+
+        victoryPoints$.subscribe((victoryPoints) => {
+          expect(victoryPoints).toEqual(3);
+        });
+      });
+    });
+
+    describe('both mastery', () => {
+      const domainsCardsFacadeMock = {
+        getCardsVictoryPointsForDomain: jest.fn(() => of(2)),
+        getMasteryDomainForType: jest.fn(() => of(ID_DOMAIN_RED)),
+      };
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [StoreModule.forRoot({})],
+          providers: [
+            { provide: DomainsCardsFacade, useValue: domainsCardsFacadeMock },
+          ],
+        });
+        service = TestBed.inject(GameRulesService);
+      });
+
+      it(`should combine cards victory points
+          and trade and strength victory points`, () => {
+        const victoryPoints$ = service.getVictoryPointsForDomain(ID_DOMAIN_RED);
+
+        victoryPoints$.subscribe((victoryPoints) => {
+          expect(victoryPoints).toEqual(4);
+        });
       });
     });
   });

--- a/libs/feature-engine/src/lib/game-rules.service.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.ts
@@ -26,9 +26,10 @@ import {
   EventValue,
   GamePhase,
   LAND_CARD_INTERFACE_NAME,
+  MasteryPointsType,
   RowValue,
 } from '@taormina/shared-models';
-import { combineLatest, Subject } from 'rxjs';
+import { combineLatest, Observable, Subject } from 'rxjs';
 import { filter, map, take, takeUntil } from 'rxjs/operators';
 
 @Injectable({
@@ -112,6 +113,28 @@ export class GameRulesService {
     this.stockPilesCards.initNewGame();
     this.eventsPileCards.initNewGame();
     this.discardPileCards.initNewGame();
+  }
+
+  getVictoryPointsForDomain(domainId: string): Observable<number> {
+    return combineLatest([
+      this.domainsCards.getCardsVictoryPointsForDomain(domainId),
+      this.domainsCards.getMasteryDomainForType(MasteryPointsType.Trade),
+      this.domainsCards.getMasteryDomainForType(MasteryPointsType.Strength),
+    ]).pipe(
+      map(
+        ([
+          cardsVictoryPoints,
+          tradeMasteryDomainId,
+          strengthMasteryDomainId,
+        ]) => {
+          return (
+            cardsVictoryPoints +
+            (tradeMasteryDomainId === domainId ? 1 : 0) +
+            (strengthMasteryDomainId === domainId ? 1 : 0)
+          );
+        }
+      )
+    );
   }
 
   drawFromStockToHand(


### PR DESCRIPTION
### Description
Get victory points from agglomeration and development cards.
Add cards victory points to mastery points.
Display total victory points above domain.

https://lhbruneton.atlassian.net/browse/TAOR-16

### Checklist
- [ ] Created tests with given/when/then blocks
- [x] Created tests for the nominal use case
- [ ] Created tests for errors
- [x] Build project without errors
