### PR TITLE
TAOR-22: On pathfinder, draw any land pile card

### DIFF
--- a/apps/taormina-duel/src/app/app.component.html
+++ b/apps/taormina-duel/src/app/app.component.html
@@ -171,7 +171,7 @@
       <div *ngIf="getLandCard(pivot.cardId) as land">
         {{ land.type }} - {{ land.die }}
         <button
-          *ngIf="i < 2"
+          *ngIf="(canSelectAnyLandCard() | async) || i < 2"
           type="button"
           (click)="selectLandsPileCard(pivot.id)"
         >

--- a/apps/taormina-duel/src/app/app.component.html
+++ b/apps/taormina-duel/src/app/app.component.html
@@ -44,7 +44,7 @@
     </div>
   </div>
   <div>
-    <p>Selected event:</p>
+    <p>Current event:</p>
     <div *ngIf="getSelectedEventsPileCard() | async as pivot">
       <div *ngIf="getEventCard(pivot.cardId) as event">
         {{ event.name }}
@@ -52,8 +52,16 @@
     </div>
     <hr />
     <button type="button" (click)="removeSelectedEventsPileCard()">
-      Discard event
+      Finish event
     </button>
+  </div>
+  <div>
+    <p>Current action:</p>
+    <div *ngIf="getAction() | async as action">
+      {{ action }}
+    </div>
+    <hr />
+    <button type="button" (click)="unsetAction()">Finish action</button>
   </div>
 </div>
 <hr />
@@ -113,6 +121,22 @@
       {{ pivot.domainId }}<br />
       {{ pivot.col }}<br />
       {{ pivot.row }}
+    </p>
+  </div>
+</div>
+<hr />
+<div class="flex-container">
+  <button
+    type="button"
+    [disabled]="useActionCardDisabled() | async"
+    (click)="useActionCard()"
+  >
+    Use action card
+  </button>
+  <div>
+    <p>Selected Action Card:</p>
+    <p *ngIf="getSelectedActionCard() | async as pivot">
+      {{ pivot.cardId }}
     </p>
   </div>
 </div>
@@ -234,13 +258,6 @@
         </div>
       </div>
     </div>
-    <button
-      *ngIf="putSelectedHandCardToDiscardPileAvailable() | async"
-      type="button"
-      (click)="putSelectedHandCardToDiscardPile()"
-    >
-      Put selected hand card on top
-    </button>
   </div>
 </div>
 <hr />

--- a/apps/taormina-duel/src/app/app.component.html
+++ b/apps/taormina-duel/src/app/app.component.html
@@ -84,8 +84,8 @@
     </p>
   </div>
   <div>
-    <p>Selected Agglomeration Available Slot:</p>
-    <p *ngIf="getSelectedDomainCard() | async as pivot">
+    <p>Selected Available Agglomeration Slot:</p>
+    <p *ngIf="getSelectedAvailableAgglomerationSlot() | async as pivot">
       {{ pivot.domainId }}<br />
       {{ pivot.col }}<br />
       {{ pivot.row }}
@@ -103,13 +103,13 @@
   </button>
   <div>
     <p>Selected Development Card:</p>
-    <p *ngIf="getSelectedHandCard() | async as pivot">
+    <p *ngIf="getSelectedDevelopmentCard() | async as pivot">
       {{ pivot.cardId }}
     </p>
   </div>
   <div>
-    <p>Selected Development Available Slot:</p>
-    <p *ngIf="getSelectedDomainCard() | async as pivot">
+    <p>Selected Available Development Slot:</p>
+    <p *ngIf="getSelectedAvailableDevelopmentSlot() | async as pivot">
       {{ pivot.domainId }}<br />
       {{ pivot.col }}<br />
       {{ pivot.row }}

--- a/apps/taormina-duel/src/app/app.component.ts
+++ b/apps/taormina-duel/src/app/app.component.ts
@@ -276,6 +276,12 @@ export class AppComponent {
     return this.landsPileCards.allLandsPileCards$;
   }
 
+  canSelectAnyLandCard(): Observable<boolean> {
+    return this.game.action$.pipe(
+      map((action) => action === ActionName.Pathfinder)
+    );
+  }
+
   selectLandsPileCard(pivotId: string): void {
     this.landsPileCards.selectLandsPileCard(pivotId);
   }

--- a/apps/taormina-duel/src/app/app.component.ts
+++ b/apps/taormina-duel/src/app/app.component.ts
@@ -56,9 +56,10 @@ import {
   MasteryPointsType,
   ResourceValue,
   RESOURCE_VALUES,
+  ActionName,
 } from '@taormina/shared-models';
 import { combineLatest, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 
 @Component({
   selector: 'taormina-root',
@@ -125,6 +126,14 @@ export class AppComponent {
 
   removeSelectedEventsPileCard(): void {
     this.eventsPileCards.removeSelected();
+  }
+
+  getAction(): Observable<ActionName | undefined> {
+    return this.game.action$;
+  }
+
+  unsetAction(): void {
+    this.game.setAction(undefined);
   }
 
   throwDisabled(): Observable<boolean> {
@@ -297,16 +306,16 @@ export class AppComponent {
     return this.discardPileCards.allDiscardPileCardsReverse$;
   }
 
-  putSelectedHandCardToDiscardPileAvailable(): Observable<boolean> {
+  useActionCardDisabled(): Observable<boolean> {
     return this.game.phase$.pipe(
       map((phase) => {
-        return phase === GamePhase.LoopActions;
+        return phase !== GamePhase.LoopActions;
       })
     );
   }
 
-  putSelectedHandCardToDiscardPile(): void {
-    this.gameRules.putFromHandToDiscardPile();
+  useActionCard(): void {
+    this.gameRules.useActionCard();
   }
 
   getRedHand(): Hand | undefined {
@@ -432,6 +441,12 @@ export class AppComponent {
       filter(
         (handCard) => handCard?.cardType === DEVELOPMENT_CARD_INTERFACE_NAME
       )
+    );
+  }
+
+  getSelectedActionCard(): Observable<HandsCardsEntity | undefined> {
+    return this.handsCards.selectedHandsCards$.pipe(
+      filter((handCard) => handCard?.cardType === ACTION_CARD_INTERFACE_NAME)
     );
   }
 

--- a/apps/taormina-duel/src/app/app.component.ts
+++ b/apps/taormina-duel/src/app/app.component.ts
@@ -427,11 +427,41 @@ export class AppComponent {
     return this.handsCards.selectedHandsCards$;
   }
 
+  getSelectedDevelopmentCard(): Observable<HandsCardsEntity | undefined> {
+    return this.handsCards.selectedHandsCards$.pipe(
+      filter(
+        (handCard) => handCard?.cardType === DEVELOPMENT_CARD_INTERFACE_NAME
+      )
+    );
+  }
+
   getSelectedLandsPileCard(): Observable<LandsPileCardsEntity | undefined> {
     return this.landsPileCards.selectedLandsPileCards$;
   }
 
   getSelectedDomainCard(): Observable<DomainsCardsEntity | undefined> {
     return this.domainsCards.selectedDomainsCards$;
+  }
+
+  getSelectedAvailableAgglomerationSlot(): Observable<
+    DomainsCardsEntity | undefined
+    // eslint-disable-next-line indent
+  > {
+    return this.domainsCards.selectedDomainsCards$.pipe(
+      filter(
+        (domainCard) => domainCard?.cardType === AVAILABLE_AGGLOMERATION_SLOT
+      )
+    );
+  }
+
+  getSelectedAvailableDevelopmentSlot(): Observable<
+    DomainsCardsEntity | undefined
+    // eslint-disable-next-line indent
+  > {
+    return this.domainsCards.selectedDomainsCards$.pipe(
+      filter(
+        (domainCard) => domainCard?.cardType === AVAILABLE_DEVELOPMENT_SLOT
+      )
+    );
   }
 }

--- a/libs/data-access-game/src/lib/+state/game/game.actions.ts
+++ b/libs/data-access-game/src/lib/+state/game/game.actions.ts
@@ -1,5 +1,6 @@
 import { createAction, props } from '@ngrx/store';
 import {
+  ActionName,
   DomainColor,
   EventValue,
   GamePhase,
@@ -16,6 +17,11 @@ export const setPhase = createAction(
 export const setPlayer = createAction(
   '[Game] Set Player',
   props<{ player: DomainColor }>()
+);
+
+export const setAction = createAction(
+  '[Game] Set Action',
+  props<{ action: ActionName | undefined }>()
 );
 
 export const throwDice = createAction('[Dice Component] Throw Dice');

--- a/libs/data-access-game/src/lib/+state/game/game.facade.ts
+++ b/libs/data-access-game/src/lib/+state/game/game.facade.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@angular/core';
 import { select, Store } from '@ngrx/store';
-import { DomainColor, GamePhase, ResourceValue } from '@taormina/shared-models';
+import {
+  ActionName,
+  DomainColor,
+  GamePhase,
+  ResourceValue,
+} from '@taormina/shared-models';
 
 import * as GameActions from './game.actions';
 import { GamePartialState } from './game.reducer';
@@ -19,6 +24,7 @@ export class GameFacade {
   eventDie$ = this.store.pipe(select(GameSelectors.getGameEventDie));
   phase$ = this.store.pipe(select(GameSelectors.getGamePhase));
   player$ = this.store.pipe(select(GameSelectors.getGamePlayer));
+  action$ = this.store.pipe(select(GameSelectors.getGameAction));
 
   constructor(private store: Store<GamePartialState>) {}
 
@@ -52,5 +58,9 @@ export class GameFacade {
 
   setPlayer(player: DomainColor): void {
     this.store.dispatch(GameActions.setPlayer({ player }));
+  }
+
+  setAction(action: ActionName | undefined): void {
+    this.store.dispatch(GameActions.setAction({ action }));
   }
 }

--- a/libs/data-access-game/src/lib/+state/game/game.reducer.spec.ts
+++ b/libs/data-access-game/src/lib/+state/game/game.reducer.spec.ts
@@ -1,5 +1,10 @@
 import { Action } from '@ngrx/store';
-import { DomainColor, EventValue, GamePhase } from '@taormina/shared-models';
+import {
+  ActionName,
+  DomainColor,
+  EventValue,
+  GamePhase,
+} from '@taormina/shared-models';
 
 import * as GameActions from './game.actions';
 import { gameReducer, GameState, initialGameState } from './game.reducer';
@@ -23,6 +28,7 @@ describe('Game Reducer', () => {
         eventDie: EventValue.Thieves,
         phase: GamePhase.InitialDraw,
         player: DomainColor.Blue,
+        action: ActionName.Goldsmith,
       };
 
       const action = GameActions.initNewGame();
@@ -41,6 +47,7 @@ describe('Game Reducer', () => {
         eventDie: undefined,
         phase: GamePhase.InitialThrow,
         player: DomainColor.Red,
+        action: undefined,
       };
 
       const action = GameActions.setProductionDie({ value: 2 });
@@ -59,6 +66,7 @@ describe('Game Reducer', () => {
         eventDie: undefined,
         phase: GamePhase.InitialThrow,
         player: DomainColor.Red,
+        action: undefined,
       };
 
       const action = GameActions.setNextProductionDie({ value: 5 });
@@ -77,6 +85,7 @@ describe('Game Reducer', () => {
         eventDie: EventValue.Thieves,
         phase: GamePhase.InitialThrow,
         player: DomainColor.Red,
+        action: undefined,
       };
 
       const action = GameActions.setEventDie({ value: EventValue.Thieves });
@@ -95,6 +104,7 @@ describe('Game Reducer', () => {
         eventDie: undefined,
         phase: GamePhase.InitialDraw,
         player: DomainColor.Red,
+        action: undefined,
       };
 
       const action = GameActions.setPhase({ phase: GamePhase.InitialDraw });
@@ -113,9 +123,29 @@ describe('Game Reducer', () => {
         eventDie: undefined,
         phase: GamePhase.InitialThrow,
         player: DomainColor.Blue,
+        action: undefined,
       };
 
       const action = GameActions.setPlayer({ player: DomainColor.Blue });
+
+      const state: GameState = gameReducer(initialGameState, action);
+
+      expect(state).toEqual(newState);
+    });
+  });
+
+  describe('setAction', () => {
+    it('should set the current action', () => {
+      const newState: GameState = {
+        productionDie: undefined,
+        nextProductionDie: undefined,
+        eventDie: undefined,
+        phase: GamePhase.InitialThrow,
+        player: DomainColor.Red,
+        action: ActionName.Goldsmith,
+      };
+
+      const action = GameActions.setAction({ action: ActionName.Goldsmith });
 
       const state: GameState = gameReducer(initialGameState, action);
 

--- a/libs/data-access-game/src/lib/+state/game/game.reducer.ts
+++ b/libs/data-access-game/src/lib/+state/game/game.reducer.ts
@@ -1,5 +1,6 @@
 import { createReducer, on } from '@ngrx/store';
 import {
+  ActionName,
   DomainColor,
   EventValue,
   GamePhase,
@@ -16,6 +17,7 @@ export interface GameState {
   eventDie: EventValue | undefined;
   phase: GamePhase;
   player: DomainColor;
+  action: ActionName | undefined;
 }
 
 export interface GamePartialState {
@@ -28,6 +30,7 @@ export const initialGameState: GameState = {
   eventDie: undefined,
   phase: GamePhase.InitialThrow,
   player: DomainColor.Red,
+  action: undefined,
 };
 
 export const gameReducer = createReducer(
@@ -52,5 +55,9 @@ export const gameReducer = createReducer(
   on(GameActions.setPlayer, (state, { player }) => ({
     ...state,
     player,
+  })),
+  on(GameActions.setAction, (state, { action }) => ({
+    ...state,
+    action,
   }))
 );

--- a/libs/data-access-game/src/lib/+state/game/game.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/game/game.selectors.spec.ts
@@ -1,5 +1,10 @@
 /* eslint-disable no-magic-numbers */
-import { DomainColor, EventValue, GamePhase } from '@taormina/shared-models';
+import {
+  ActionName,
+  DomainColor,
+  EventValue,
+  GamePhase,
+} from '@taormina/shared-models';
 
 import { GamePartialState, initialGameState } from './game.reducer';
 import * as GameSelectors from './game.selectors';
@@ -14,6 +19,7 @@ describe('Game Selectors', () => {
         productionDie: 1,
         nextProductionDie: 6,
         eventDie: EventValue.Event,
+        action: ActionName.Goldsmith,
       },
     };
   });
@@ -55,6 +61,14 @@ describe('Game Selectors', () => {
       const result = GameSelectors.getGamePlayer(state);
 
       expect(result).toBe(DomainColor.Red);
+    });
+  });
+
+  describe('getGameAction()', () => {
+    it('should return the current action', () => {
+      const result = GameSelectors.getGameAction(state);
+
+      expect(result).toBe(ActionName.Goldsmith);
     });
   });
 });

--- a/libs/data-access-game/src/lib/+state/game/game.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/game/game.selectors.ts
@@ -2,9 +2,8 @@ import { createFeatureSelector, createSelector } from '@ngrx/store';
 import { GamePartialState, GameState, GAME_FEATURE_KEY } from './game.reducer';
 
 // Lookup the 'Game' feature state managed by NgRx
-export const getGameState = createFeatureSelector<GamePartialState, GameState>(
-  GAME_FEATURE_KEY
-);
+export const getGameState =
+  createFeatureSelector<GamePartialState, GameState>(GAME_FEATURE_KEY);
 
 export const getGameProductionDie = createSelector(
   getGameState,
@@ -29,4 +28,9 @@ export const getGamePhase = createSelector(
 export const getGamePlayer = createSelector(
   getGameState,
   (state: GameState) => state.player
+);
+
+export const getGameAction = createSelector(
+  getGameState,
+  (state: GameState) => state.action
 );

--- a/libs/feature-engine/src/lib/game-rules.service.spec.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.spec.ts
@@ -20,6 +20,7 @@ import {
   ID_HAND_RED,
 } from '@taormina/shared-constants';
 import {
+  ActionName,
   ACTION_CARD_INTERFACE_NAME,
   AGGLOMERATION_CARD_INTERFACE_NAME,
   AVAILABLE_AGGLOMERATION_SLOT,
@@ -1313,8 +1314,13 @@ describe('GameRulesService', () => {
     });
   });
 
-  describe('putFromHandToDiscardPile', () => {
+  describe('useActionCard', () => {
     describe('OK', () => {
+      const gameFacadeMock = {
+        eventDie$: of(),
+        productionDie$: of(),
+        setAction: jest.fn(),
+      };
       const handsCardsFacadeMock = {
         selectedHandsCards$: of({
           id: 'aaaa',
@@ -1333,6 +1339,7 @@ describe('GameRulesService', () => {
         TestBed.configureTestingModule({
           imports: [StoreModule.forRoot({})],
           providers: [
+            { provide: GameFacade, useValue: gameFacadeMock },
             { provide: HandsCardsFacade, useValue: handsCardsFacadeMock },
             {
               provide: DiscardPileCardsFacade,
@@ -1344,13 +1351,16 @@ describe('GameRulesService', () => {
       });
 
       it(`should call removeHandCard and unselectHandCard,
-          then addCardToDiscardPile`, () => {
-        service.putFromHandToDiscardPile();
+          then setAction and addCardToDiscardPile`, () => {
+        service.useActionCard();
 
         expect(handsCardsFacadeMock.removeHandCard).toHaveBeenCalledWith(
           'aaaa'
         );
         expect(handsCardsFacadeMock.unselectHandCard).toHaveBeenCalledTimes(1);
+        expect(gameFacadeMock.setAction).toHaveBeenCalledWith(
+          ActionName.Soothsayer
+        );
         expect(
           discardPileCardsFacadeMock.addCardToDiscardPile
         ).toHaveBeenCalledWith({
@@ -1361,6 +1371,11 @@ describe('GameRulesService', () => {
     });
 
     describe('NOK undefined selectedHandsCards', () => {
+      const gameFacadeMock = {
+        eventDie$: of(),
+        productionDie$: of(),
+        setAction: jest.fn(),
+      };
       const handsCardsFacadeMock = {
         selectedHandsCards$: of(undefined),
         removeHandCard: jest.fn(),
@@ -1374,6 +1389,7 @@ describe('GameRulesService', () => {
         TestBed.configureTestingModule({
           imports: [StoreModule.forRoot({})],
           providers: [
+            { provide: GameFacade, useValue: gameFacadeMock },
             { provide: HandsCardsFacade, useValue: handsCardsFacadeMock },
             {
               provide: DiscardPileCardsFacade,
@@ -1386,10 +1402,155 @@ describe('GameRulesService', () => {
 
       // FIXME: should test error thrown
       it('should not call', () => {
-        service.putFromHandToDiscardPile();
+        service.useActionCard();
 
         expect(handsCardsFacadeMock.removeHandCard).not.toHaveBeenCalled();
         expect(handsCardsFacadeMock.unselectHandCard).not.toHaveBeenCalled();
+        expect(gameFacadeMock.setAction).not.toHaveBeenCalled();
+        expect(
+          discardPileCardsFacadeMock.addCardToDiscardPile
+        ).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('NOK cardType', () => {
+      const gameFacadeMock = {
+        eventDie$: of(),
+        productionDie$: of(),
+        setAction: jest.fn(),
+      };
+      const handsCardsFacadeMock = {
+        selectedHandsCards$: of({
+          id: 'aaaa',
+          handId: ID_HAND_BLUE,
+          cardType: DEVELOPMENT_CARD_INTERFACE_NAME,
+          cardId: 'ACTION_1',
+        }),
+        removeHandCard: jest.fn(),
+        unselectHandCard: jest.fn(),
+      };
+      const discardPileCardsFacadeMock = {
+        addCardToDiscardPile: jest.fn(),
+      };
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [StoreModule.forRoot({})],
+          providers: [
+            { provide: GameFacade, useValue: gameFacadeMock },
+            { provide: HandsCardsFacade, useValue: handsCardsFacadeMock },
+            {
+              provide: DiscardPileCardsFacade,
+              useValue: discardPileCardsFacadeMock,
+            },
+          ],
+        });
+        service = TestBed.inject(GameRulesService);
+      });
+
+      // FIXME: should test error thrown
+      it('should not call', () => {
+        service.useActionCard();
+
+        expect(handsCardsFacadeMock.removeHandCard).not.toHaveBeenCalled();
+        expect(handsCardsFacadeMock.unselectHandCard).not.toHaveBeenCalled();
+        expect(gameFacadeMock.setAction).not.toHaveBeenCalled();
+        expect(
+          discardPileCardsFacadeMock.addCardToDiscardPile
+        ).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('NOK cardId', () => {
+      const gameFacadeMock = {
+        eventDie$: of(),
+        productionDie$: of(),
+        setAction: jest.fn(),
+      };
+      const handsCardsFacadeMock = {
+        selectedHandsCards$: of({
+          id: 'aaaa',
+          handId: ID_HAND_BLUE,
+          cardType: ACTION_CARD_INTERFACE_NAME,
+          cardId: undefined,
+        }),
+        removeHandCard: jest.fn(),
+        unselectHandCard: jest.fn(),
+      };
+      const discardPileCardsFacadeMock = {
+        addCardToDiscardPile: jest.fn(),
+      };
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [StoreModule.forRoot({})],
+          providers: [
+            { provide: GameFacade, useValue: gameFacadeMock },
+            { provide: HandsCardsFacade, useValue: handsCardsFacadeMock },
+            {
+              provide: DiscardPileCardsFacade,
+              useValue: discardPileCardsFacadeMock,
+            },
+          ],
+        });
+        service = TestBed.inject(GameRulesService);
+      });
+
+      // FIXME: should test error thrown
+      it('should not call', () => {
+        service.useActionCard();
+
+        expect(handsCardsFacadeMock.removeHandCard).not.toHaveBeenCalled();
+        expect(handsCardsFacadeMock.unselectHandCard).not.toHaveBeenCalled();
+        expect(gameFacadeMock.setAction).not.toHaveBeenCalled();
+        expect(
+          discardPileCardsFacadeMock.addCardToDiscardPile
+        ).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('NOK actionCards get undefined', () => {
+      const gameFacadeMock = {
+        eventDie$: of(),
+        productionDie$: of(),
+        setAction: jest.fn(),
+      };
+      const handsCardsFacadeMock = {
+        selectedHandsCards$: of({
+          id: 'aaaa',
+          handId: ID_HAND_BLUE,
+          cardType: ACTION_CARD_INTERFACE_NAME,
+          cardId: 'ACTION_10',
+        }),
+        removeHandCard: jest.fn(),
+        unselectHandCard: jest.fn(),
+      };
+      const discardPileCardsFacadeMock = {
+        addCardToDiscardPile: jest.fn(),
+      };
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [StoreModule.forRoot({})],
+          providers: [
+            { provide: GameFacade, useValue: gameFacadeMock },
+            { provide: HandsCardsFacade, useValue: handsCardsFacadeMock },
+            {
+              provide: DiscardPileCardsFacade,
+              useValue: discardPileCardsFacadeMock,
+            },
+          ],
+        });
+        service = TestBed.inject(GameRulesService);
+      });
+
+      // FIXME: should test error thrown
+      it('should not call', () => {
+        service.useActionCard();
+
+        expect(handsCardsFacadeMock.removeHandCard).not.toHaveBeenCalled();
+        expect(handsCardsFacadeMock.unselectHandCard).not.toHaveBeenCalled();
+        expect(gameFacadeMock.setAction).not.toHaveBeenCalled();
         expect(
           discardPileCardsFacadeMock.addCardToDiscardPile
         ).not.toHaveBeenCalled();

--- a/libs/feature-engine/src/lib/game-rules.service.ts
+++ b/libs/feature-engine/src/lib/game-rules.service.ts
@@ -11,11 +11,13 @@ import {
   StockPilesCardsFacade,
 } from '@taormina/data-access-game';
 import {
+  actionCards,
   eventCards,
   ID_FACE_UP_HAMLET,
   ID_FACE_UP_TOWN,
 } from '@taormina/shared-constants';
 import {
+  ACTION_CARD_INTERFACE_NAME,
   AGGLOMERATION_CARD_INTERFACE_NAME,
   AVAILABLE_AGGLOMERATION_SLOT,
   AVAILABLE_DEVELOPMENT_SLOT,
@@ -317,7 +319,7 @@ export class GameRulesService {
       .subscribe();
   }
 
-  putFromHandToDiscardPile(): void {
+  useActionCard(): void {
     this.handsCards.selectedHandsCards$
       .pipe(
         take(1),
@@ -325,8 +327,21 @@ export class GameRulesService {
           if (handCard === undefined) {
             throw new Error(`Can't put card in pile if no card selected.`);
           }
+          if (
+            handCard.cardType !== ACTION_CARD_INTERFACE_NAME ||
+            handCard.cardId === undefined
+          ) {
+            throw new Error(`Can't use card other than action.`);
+          }
+          const action = actionCards.get(handCard.cardId);
+          if (action === undefined) {
+            throw new Error(
+              `Something went wrong, action shouldn't be undefined at this point.`
+            );
+          }
           this.handsCards.removeHandCard(handCard.id);
           this.handsCards.unselectHandCard();
+          this.game.setAction(action.name);
           this.discardPileCards.addCardToDiscardPile({
             type: handCard.cardType,
             id: handCard.cardId,


### PR DESCRIPTION
### Description
Add current action to the game state.
Cleanup app to be more precise on selected domain and hand card type.
On pathfinder action, allow to take any land pile card.

https://lhbruneton.atlassian.net/browse/TAOR-22

### Checklist
- [ ] Created tests with given/when/then blocks
- [x] Created tests for the nominal use case
- [x] Created tests for errors
- [x] Build project without errors
