### PR TITLE
TAOR-52: Refactor deprecated selectors with props to factory selectors

### DIFF
--- a/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/discard-pile-cards/discard-pile-cards.selectors.ts
@@ -2,14 +2,12 @@ import { createFeatureSelector, createSelector } from '@ngrx/store';
 import {
   DISCARD_PILE_CARDS_FEATURE_KEY,
   DiscardPileCardsState,
-  DiscardPileCardsPartialState,
   discardPileCardsAdapter,
 } from './discard-pile-cards.reducer';
 
 // Lookup the 'DiscardPileCards' feature state managed by NgRx
-export const getDiscardPileCardsState = createFeatureSelector<
-  DiscardPileCardsState
->(DISCARD_PILE_CARDS_FEATURE_KEY);
+export const getDiscardPileCardsState =
+  createFeatureSelector<DiscardPileCardsState>(DISCARD_PILE_CARDS_FEATURE_KEY);
 
 const { selectAll, selectEntities } = discardPileCardsAdapter.getSelectors();
 

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.spec.ts
@@ -99,8 +99,9 @@ describe('DomainsCardsEffects', () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         .mockImplementation((_die: ResourceValue) =>
           createSelector(
-            () => null,
-            () => [
+            () => [],
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            (_) => [
               {
                 id: 'AAA',
                 domainId: ID_DOMAIN_RED,
@@ -124,8 +125,9 @@ describe('DomainsCardsEffects', () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         .mockImplementation((_die: ResourceValue) =>
           createSelector(
-            () => null,
-            () => [
+            () => [],
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            (_) => [
               {
                 id: 'CCC',
                 domainId: ID_DOMAIN_BLUE,
@@ -189,8 +191,9 @@ describe('DomainsCardsEffects', () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           .mockImplementation((_id: string) =>
             createSelector(
-              () => null,
-              () =>
+              () => [],
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              (_) =>
                 ({
                   id: 'AAA',
                   domainId: ID_DOMAIN_RED,
@@ -226,8 +229,9 @@ describe('DomainsCardsEffects', () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           .mockImplementation((_id: string) =>
             createSelector(
-              () => null,
-              () =>
+              () => [],
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              (_) =>
                 undefined as DomainsCardsModels.DomainsCardsEntity | undefined
             )
           );
@@ -254,8 +258,9 @@ describe('DomainsCardsEffects', () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           .mockImplementation((_id: string) =>
             createSelector(
-              () => null,
-              () =>
+              () => [],
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              (_) =>
                 ({
                   id: 'AAA',
                   domainId: ID_DOMAIN_RED,
@@ -289,8 +294,9 @@ describe('DomainsCardsEffects', () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           .mockImplementation((_id: string) =>
             createSelector(
-              () => null,
-              () =>
+              () => [],
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              (_) =>
                 ({
                   id: 'AAA',
                   domainId: ID_DOMAIN_RED,
@@ -327,8 +333,9 @@ describe('DomainsCardsEffects', () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           .mockImplementation((_id: string) =>
             createSelector(
-              () => null,
-              () =>
+              () => [],
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              (_) =>
                 ({
                   id: 'AAA',
                   domainId: ID_DOMAIN_RED,
@@ -364,8 +371,9 @@ describe('DomainsCardsEffects', () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           .mockImplementation((_id: string) =>
             createSelector(
-              () => null,
-              () =>
+              () => [],
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              (_) =>
                 undefined as DomainsCardsModels.DomainsCardsEntity | undefined
             )
           );
@@ -392,8 +400,9 @@ describe('DomainsCardsEffects', () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           .mockImplementation((_id: string) =>
             createSelector(
-              () => null,
-              () =>
+              () => [],
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              (_) =>
                 ({
                   id: 'AAA',
                   domainId: ID_DOMAIN_RED,
@@ -904,8 +913,9 @@ describe('DomainsCardsEffects', () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           .mockImplementation((_id: string) =>
             createSelector(
-              () => null,
-              () =>
+              () => [],
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              (_) =>
                 ({
                   id: 'AAA',
                   domainId: ID_DOMAIN_RED,
@@ -941,8 +951,9 @@ describe('DomainsCardsEffects', () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           .mockImplementation((_id: string) =>
             createSelector(
-              () => null,
-              () =>
+              () => [],
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              (_) =>
                 undefined as DomainsCardsModels.DomainsCardsEntity | undefined
             )
           );
@@ -969,8 +980,9 @@ describe('DomainsCardsEffects', () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           .mockImplementation((_id: string) =>
             createSelector(
-              () => null,
-              () =>
+              () => [],
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              (_) =>
                 ({
                   id: 'AAA',
                   domainId: ID_DOMAIN_RED,
@@ -1061,28 +1073,33 @@ describe('DomainsCardsEffects', () => {
                 {
                   selector:
                     DomainsCardsSelectors.getDomainResourceCountSeenByThieves,
-                  value: 7,
+                  // eslint-disable-next-line no-magic-numbers
+                  value: [6, 7],
                 },
                 {
                   selector:
                     DomainsCardsSelectors.getDomainUnprotectedGoldMinesAndPastures,
                   value: [
-                    {
-                      id: 'aaaa',
-                      domainId: ID_DOMAIN_RED,
-                      cardType: LAND_CARD_INTERFACE_NAME,
-                      cardId: ID_GOLD_MINE_RED,
-                      availableResources: 1,
-                      lockedResources: 0,
-                    },
-                    {
-                      id: 'bbbb',
-                      domainId: ID_DOMAIN_BLUE,
-                      cardType: LAND_CARD_INTERFACE_NAME,
-                      cardId: ID_PASTURE_BLUE,
-                      availableResources: 1,
-                      lockedResources: 0,
-                    },
+                    [
+                      {
+                        id: 'aaaa',
+                        domainId: ID_DOMAIN_RED,
+                        cardType: LAND_CARD_INTERFACE_NAME,
+                        cardId: ID_GOLD_MINE_RED,
+                        availableResources: 1,
+                        lockedResources: 0,
+                      },
+                    ],
+                    [
+                      {
+                        id: 'bbbb',
+                        domainId: ID_DOMAIN_BLUE,
+                        cardType: LAND_CARD_INTERFACE_NAME,
+                        cardId: ID_PASTURE_BLUE,
+                        availableResources: 1,
+                        lockedResources: 0,
+                      },
+                    ],
                   ],
                 },
               ],
@@ -1114,28 +1131,33 @@ describe('DomainsCardsEffects', () => {
                 {
                   selector:
                     DomainsCardsSelectors.getDomainResourceCountSeenByThieves,
-                  value: 8,
+                  // eslint-disable-next-line no-magic-numbers
+                  value: [8, 7],
                 },
                 {
                   selector:
                     DomainsCardsSelectors.getDomainUnprotectedGoldMinesAndPastures,
                   value: [
-                    {
-                      id: 'aaaa',
-                      domainId: ID_DOMAIN_RED,
-                      cardType: LAND_CARD_INTERFACE_NAME,
-                      cardId: ID_GOLD_MINE_RED,
-                      availableResources: 1,
-                      lockedResources: 0,
-                    },
-                    {
-                      id: 'bbbb',
-                      domainId: ID_DOMAIN_BLUE,
-                      cardType: LAND_CARD_INTERFACE_NAME,
-                      cardId: ID_PASTURE_BLUE,
-                      availableResources: 1,
-                      lockedResources: 0,
-                    },
+                    [
+                      {
+                        id: 'aaaa',
+                        domainId: ID_DOMAIN_RED,
+                        cardType: LAND_CARD_INTERFACE_NAME,
+                        cardId: ID_GOLD_MINE_RED,
+                        availableResources: 1,
+                        lockedResources: 0,
+                      },
+                    ],
+                    [
+                      {
+                        id: 'bbbb',
+                        domainId: ID_DOMAIN_BLUE,
+                        cardType: LAND_CARD_INTERFACE_NAME,
+                        cardId: ID_PASTURE_BLUE,
+                        availableResources: 1,
+                        lockedResources: 0,
+                      },
+                    ],
                   ],
                 },
               ],
@@ -1157,19 +1179,6 @@ describe('DomainsCardsEffects', () => {
                 id: 'aaaa',
                 changes: { availableResources: 0 },
               },
-              {
-                id: 'bbbb',
-                changes: { availableResources: 0 },
-              },
-              // FIXME: https://github.com/ngrx/platform/issues/2176
-              {
-                id: 'aaaa',
-                changes: { availableResources: 0 },
-              },
-              {
-                id: 'bbbb',
-                changes: { availableResources: 0 },
-              },
             ],
           }),
         });
@@ -1187,16 +1196,44 @@ describe('DomainsCardsEffects', () => {
             selectors: [
               {
                 selector:
-                  // FIXME: https://github.com/ngrx/platform/issues/2176
                   DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear,
                 value: [
-                  {
-                    id: 'aaaa',
-                    domainId: ID_DOMAIN_RED,
-                    cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: ID_CLAY_PIT_RED,
-                    availableResources: 0,
-                  },
+                  [
+                    {
+                      id: 'aaaa',
+                      domainId: ID_DOMAIN_RED,
+                      cardType: LAND_CARD_INTERFACE_NAME,
+                      cardId: 'LAND_1',
+                      availableResources: 0,
+                    },
+                  ],
+                  [
+                    {
+                      id: 'bbbb',
+                      domainId: ID_DOMAIN_BLUE,
+                      cardType: LAND_CARD_INTERFACE_NAME,
+                      cardId: 'LAND_2',
+                      availableResources: 0,
+                    },
+                  ],
+                  [
+                    {
+                      id: 'cccc',
+                      domainId: ID_DOMAIN_BLUE,
+                      cardType: LAND_CARD_INTERFACE_NAME,
+                      cardId: 'LAND_3',
+                      availableResources: 0,
+                    },
+                  ],
+                  [
+                    {
+                      id: 'dddd',
+                      domainId: ID_DOMAIN_RED,
+                      cardType: LAND_CARD_INTERFACE_NAME,
+                      cardId: 'LAND_4',
+                      availableResources: 0,
+                    },
+                  ],
                 ],
               },
             ],
@@ -1219,15 +1256,15 @@ describe('DomainsCardsEffects', () => {
               changes: { availableResources: 1 },
             },
             {
-              id: 'aaaa',
+              id: 'bbbb',
               changes: { availableResources: 2 },
             },
             {
-              id: 'aaaa',
+              id: 'cccc',
               changes: { availableResources: 3 },
             },
             {
-              id: 'aaaa',
+              id: 'dddd',
               changes: { availableResources: 3 },
             },
           ],

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.spec.ts
@@ -1,7 +1,7 @@
 import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { Action } from '@ngrx/store';
+import { Action, createSelector } from '@ngrx/store';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { DataPersistence, NxModule } from '@nrwl/angular';
 import {
@@ -17,6 +17,7 @@ import {
 import {
   AVAILABLE_AGGLOMERATION_SLOT,
   LAND_CARD_INTERFACE_NAME,
+  ResourceValue,
 } from '@taormina/shared-models';
 import { hot } from 'jasmine-marbles';
 import { Observable } from 'rxjs';
@@ -89,71 +90,71 @@ describe('DomainsCardsEffects', () => {
   });
 
   describe('increaseResourcesForDie$', () => {
-    beforeEach(() => {
-      injector = Injector.create({
-        providers: [
-          provideMockStore({
-            selectors: [
-              {
-                selector:
-                  DomainsCardsSelectors.getLandCardsPivotsIncreaseOneProduction,
-                value: [
-                  {
-                    id: 'AAA',
-                    domainId: ID_DOMAIN_RED,
-                    cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: ID_CLAY_PIT_RED,
-                    availableResources: 0,
-                  },
-                  {
-                    id: 'BBB',
-                    domainId: ID_DOMAIN_RED,
-                    cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: ID_CLAY_PIT_RED,
-                    availableResources: 3,
-                  },
-                ],
-              },
-              {
-                selector:
-                  DomainsCardsSelectors.getLandCardsPivotsIncreaseTwoProduction,
-                value: [
-                  {
-                    id: 'CCC',
-                    domainId: ID_DOMAIN_BLUE,
-                    cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: ID_FOREST_BLUE,
-                    availableResources: 0,
-                  },
-                  {
-                    id: 'DDD',
-                    domainId: ID_DOMAIN_BLUE,
-                    cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: ID_FOREST_BLUE,
-                    availableResources: 2,
-                  },
-                  {
-                    id: 'EEE',
-                    domainId: ID_DOMAIN_BLUE,
-                    cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: ID_FOREST_BLUE,
-                    availableResources: 3,
-                  },
-                ],
-              },
-            ],
-          }),
-        ],
-      });
-      injector.get(MockStore);
-    });
-
     it(`should dispatch updateDomainsCards
         with availableResources + 1
         when not next to a production building
         and availableResources < 3`, () => {
+      jest
+        .spyOn(DomainsCardsSelectors, 'getLandCardsPivotsIncreaseOneProduction')
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        .mockImplementation((_die: ResourceValue) =>
+          createSelector(
+            () => null,
+            () => [
+              {
+                id: 'AAA',
+                domainId: ID_DOMAIN_RED,
+                cardType: LAND_CARD_INTERFACE_NAME,
+                cardId: ID_CLAY_PIT_RED,
+                availableResources: 0,
+              } as DomainsCardsModels.DomainsCardsEntity,
+              {
+                id: 'BBB',
+                domainId: ID_DOMAIN_RED,
+                cardType: LAND_CARD_INTERFACE_NAME,
+                cardId: ID_CLAY_PIT_RED,
+                availableResources: 3,
+              } as DomainsCardsModels.DomainsCardsEntity,
+            ]
+          )
+        );
+
+      jest
+        .spyOn(DomainsCardsSelectors, 'getLandCardsPivotsIncreaseTwoProduction')
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        .mockImplementation((_die: ResourceValue) =>
+          createSelector(
+            () => null,
+            () => [
+              {
+                id: 'CCC',
+                domainId: ID_DOMAIN_BLUE,
+                cardType: LAND_CARD_INTERFACE_NAME,
+                cardId: ID_FOREST_BLUE,
+                availableResources: 0,
+              } as DomainsCardsModels.DomainsCardsEntity,
+              {
+                id: 'DDD',
+                domainId: ID_DOMAIN_BLUE,
+                cardType: LAND_CARD_INTERFACE_NAME,
+                cardId: ID_FOREST_BLUE,
+                availableResources: 2,
+              } as DomainsCardsModels.DomainsCardsEntity,
+              {
+                id: 'EEE',
+                domainId: ID_DOMAIN_BLUE,
+                cardType: LAND_CARD_INTERFACE_NAME,
+                cardId: ID_FOREST_BLUE,
+                availableResources: 3,
+              } as DomainsCardsModels.DomainsCardsEntity,
+            ]
+          )
+        );
+
       actions = hot('-a-|', {
-        a: DomainsCardsActions.increaseAvailableResourcesForDie({ die: 3 }),
+        a: DomainsCardsActions.increaseAvailableResourcesForDie({
+          die: 3,
+        }),
       });
 
       const expected = hot('-a-|', {
@@ -181,31 +182,26 @@ describe('DomainsCardsEffects', () => {
 
   describe('lockResource$', () => {
     describe('OK', () => {
-      beforeEach(() => {
-        injector = Injector.create({
-          providers: [
-            provideMockStore({
-              selectors: [
-                {
-                  selector: DomainsCardsSelectors.getLandCardPivotById,
-                  value: {
-                    id: 'AAA',
-                    domainId: ID_DOMAIN_RED,
-                    cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: 'LAND_1',
-                    availableResources: 3,
-                    lockedResources: 0,
-                  },
-                },
-              ],
-            }),
-          ],
-        });
-        injector.get(MockStore);
-      });
-
       it(`should dispatch updateDomainCard
           with availableResources - 1 and lockedResources + 1`, () => {
+        jest
+          .spyOn(DomainsCardsSelectors, 'getLandCardPivotById')
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          .mockImplementation((_id: string) =>
+            createSelector(
+              () => null,
+              () =>
+                ({
+                  id: 'AAA',
+                  domainId: ID_DOMAIN_RED,
+                  cardType: LAND_CARD_INTERFACE_NAME,
+                  cardId: 'LAND_1',
+                  availableResources: 3,
+                  lockedResources: 0,
+                } as DomainsCardsModels.DomainsCardsEntity | undefined)
+            )
+          );
+
         actions = hot('-a-|', {
           a: DomainsCardsActions.lockResource({ id: 'AAA' }),
         });
@@ -224,23 +220,18 @@ describe('DomainsCardsEffects', () => {
     });
 
     describe('KO pivot undefined', () => {
-      beforeEach(() => {
-        injector = Injector.create({
-          providers: [
-            provideMockStore({
-              selectors: [
-                {
-                  selector: DomainsCardsSelectors.getLandCardPivotById,
-                  value: undefined,
-                },
-              ],
-            }),
-          ],
-        });
-        injector.get(MockStore);
-      });
-
       it('should dispatch setDomainsCardsError with pivot error', () => {
+        jest
+          .spyOn(DomainsCardsSelectors, 'getLandCardPivotById')
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          .mockImplementation((_id: string) =>
+            createSelector(
+              () => null,
+              () =>
+                undefined as DomainsCardsModels.DomainsCardsEntity | undefined
+            )
+          );
+
         actions = hot('-a-|', {
           a: DomainsCardsActions.lockResource({ id: 'AAA' }),
         });
@@ -256,31 +247,26 @@ describe('DomainsCardsEffects', () => {
     });
 
     describe('KO unavailable resource', () => {
-      beforeEach(() => {
-        injector = Injector.create({
-          providers: [
-            provideMockStore({
-              selectors: [
-                {
-                  selector: DomainsCardsSelectors.getLandCardPivotById,
-                  value: {
-                    id: 'AAA',
-                    domainId: ID_DOMAIN_RED,
-                    cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: 'LAND_1',
-                    availableResources: 0,
-                    lockedResources: 0,
-                  },
-                },
-              ],
-            }),
-          ],
-        });
-        injector.get(MockStore);
-      });
-
       it(`should dispatch setDomainsCardsError
           with unavailable resource error`, () => {
+        jest
+          .spyOn(DomainsCardsSelectors, 'getLandCardPivotById')
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          .mockImplementation((_id: string) =>
+            createSelector(
+              () => null,
+              () =>
+                ({
+                  id: 'AAA',
+                  domainId: ID_DOMAIN_RED,
+                  cardType: LAND_CARD_INTERFACE_NAME,
+                  cardId: 'LAND_1',
+                  availableResources: 0,
+                  lockedResources: 0,
+                } as DomainsCardsModels.DomainsCardsEntity | undefined)
+            )
+          );
+
         actions = hot('-a-|', {
           a: DomainsCardsActions.lockResource({ id: 'AAA' }),
         });
@@ -296,31 +282,26 @@ describe('DomainsCardsEffects', () => {
     });
 
     describe('KO too many locked resources', () => {
-      beforeEach(() => {
-        injector = Injector.create({
-          providers: [
-            provideMockStore({
-              selectors: [
-                {
-                  selector: DomainsCardsSelectors.getLandCardPivotById,
-                  value: {
-                    id: 'AAA',
-                    domainId: ID_DOMAIN_RED,
-                    cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: 'LAND_1',
-                    availableResources: 1,
-                    lockedResources: 3,
-                  },
-                },
-              ],
-            }),
-          ],
-        });
-        injector.get(MockStore);
-      });
-
       it(`should dispatch setDomainsCardsError
           with too many locked resources error`, () => {
+        jest
+          .spyOn(DomainsCardsSelectors, 'getLandCardPivotById')
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          .mockImplementation((_id: string) =>
+            createSelector(
+              () => null,
+              () =>
+                ({
+                  id: 'AAA',
+                  domainId: ID_DOMAIN_RED,
+                  cardType: LAND_CARD_INTERFACE_NAME,
+                  cardId: 'LAND_1',
+                  availableResources: 1,
+                  lockedResources: 3,
+                } as DomainsCardsModels.DomainsCardsEntity | undefined)
+            )
+          );
+
         actions = hot('-a-|', {
           a: DomainsCardsActions.lockResource({ id: 'AAA' }),
         });
@@ -338,32 +319,27 @@ describe('DomainsCardsEffects', () => {
 
   describe('unlockResources$', () => {
     describe('OK', () => {
-      beforeEach(() => {
-        injector = Injector.create({
-          providers: [
-            provideMockStore({
-              selectors: [
-                {
-                  selector: DomainsCardsSelectors.getLandCardPivotById,
-                  value: {
-                    id: 'AAA',
-                    domainId: ID_DOMAIN_RED,
-                    cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: 'LAND_1',
-                    availableResources: 1,
-                    lockedResources: 2,
-                  },
-                },
-              ],
-            }),
-          ],
-        });
-        injector.get(MockStore);
-      });
-
       it(`should dispatch updateDomainCard
           with availableResources += lockedResources
           and lockedResources = 0`, () => {
+        jest
+          .spyOn(DomainsCardsSelectors, 'getLandCardPivotById')
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          .mockImplementation((_id: string) =>
+            createSelector(
+              () => null,
+              () =>
+                ({
+                  id: 'AAA',
+                  domainId: ID_DOMAIN_RED,
+                  cardType: LAND_CARD_INTERFACE_NAME,
+                  cardId: 'LAND_1',
+                  availableResources: 1,
+                  lockedResources: 2,
+                } as DomainsCardsModels.DomainsCardsEntity | undefined)
+            )
+          );
+
         actions = hot('-a-|', {
           a: DomainsCardsActions.unlockResources({ id: 'AAA' }),
         });
@@ -382,23 +358,18 @@ describe('DomainsCardsEffects', () => {
     });
 
     describe('KO pivot undefined', () => {
-      beforeEach(() => {
-        injector = Injector.create({
-          providers: [
-            provideMockStore({
-              selectors: [
-                {
-                  selector: DomainsCardsSelectors.getLandCardPivotById,
-                  value: undefined,
-                },
-              ],
-            }),
-          ],
-        });
-        injector.get(MockStore);
-      });
-
       it('should dispatch setDomainsCardsError with pivot error', () => {
+        jest
+          .spyOn(DomainsCardsSelectors, 'getLandCardPivotById')
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          .mockImplementation((_id: string) =>
+            createSelector(
+              () => null,
+              () =>
+                undefined as DomainsCardsModels.DomainsCardsEntity | undefined
+            )
+          );
+
         actions = hot('-a-|', {
           a: DomainsCardsActions.unlockResources({ id: 'AAA' }),
         });
@@ -414,31 +385,26 @@ describe('DomainsCardsEffects', () => {
     });
 
     describe('KO too many locked resources', () => {
-      beforeEach(() => {
-        injector = Injector.create({
-          providers: [
-            provideMockStore({
-              selectors: [
-                {
-                  selector: DomainsCardsSelectors.getLandCardPivotById,
-                  value: {
-                    id: 'AAA',
-                    domainId: ID_DOMAIN_RED,
-                    cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: 'LAND_1',
-                    availableResources: 2,
-                    lockedResources: 2,
-                  },
-                },
-              ],
-            }),
-          ],
-        });
-        injector.get(MockStore);
-      });
-
       it(`should dispatch setDomainsCardsError
           with too many locked resources error`, () => {
+        jest
+          .spyOn(DomainsCardsSelectors, 'getLandCardPivotById')
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          .mockImplementation((_id: string) =>
+            createSelector(
+              () => null,
+              () =>
+                ({
+                  id: 'AAA',
+                  domainId: ID_DOMAIN_RED,
+                  cardType: LAND_CARD_INTERFACE_NAME,
+                  cardId: 'LAND_1',
+                  availableResources: 2,
+                  lockedResources: 2,
+                } as DomainsCardsModels.DomainsCardsEntity | undefined)
+            )
+          );
+
         actions = hot('-a-|', {
           a: DomainsCardsActions.unlockResources({ id: 'AAA' }),
         });
@@ -932,30 +898,25 @@ describe('DomainsCardsEffects', () => {
 
   describe('increaseResources$', () => {
     describe('OK', () => {
-      beforeEach(() => {
-        injector = Injector.create({
-          providers: [
-            provideMockStore({
-              selectors: [
-                {
-                  selector: DomainsCardsSelectors.getLandCardPivotById,
-                  value: {
-                    id: 'AAA',
-                    domainId: ID_DOMAIN_RED,
-                    cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: 'LAND_1',
-                    availableResources: 0,
-                    lockedResources: 0,
-                  },
-                },
-              ],
-            }),
-          ],
-        });
-        injector.get(MockStore);
-      });
-
       it('should dispatch updateDomainCard with availableResources + 1', () => {
+        jest
+          .spyOn(DomainsCardsSelectors, 'getLandCardPivotById')
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          .mockImplementation((_id: string) =>
+            createSelector(
+              () => null,
+              () =>
+                ({
+                  id: 'AAA',
+                  domainId: ID_DOMAIN_RED,
+                  cardType: LAND_CARD_INTERFACE_NAME,
+                  cardId: 'LAND_1',
+                  availableResources: 0,
+                  lockedResources: 0,
+                } as DomainsCardsModels.DomainsCardsEntity | undefined)
+            )
+          );
+
         actions = hot('-a-|', {
           a: DomainsCardsActions.increaseAvailableResources({ id: 'AAA' }),
         });
@@ -974,23 +935,18 @@ describe('DomainsCardsEffects', () => {
     });
 
     describe('KO pivot undefined', () => {
-      beforeEach(() => {
-        injector = Injector.create({
-          providers: [
-            provideMockStore({
-              selectors: [
-                {
-                  selector: DomainsCardsSelectors.getLandCardPivotById,
-                  value: undefined,
-                },
-              ],
-            }),
-          ],
-        });
-        injector.get(MockStore);
-      });
-
       it('should dispatch setDomainsCardsError with pivot error', () => {
+        jest
+          .spyOn(DomainsCardsSelectors, 'getLandCardPivotById')
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          .mockImplementation((_id: string) =>
+            createSelector(
+              () => null,
+              () =>
+                undefined as DomainsCardsModels.DomainsCardsEntity | undefined
+            )
+          );
+
         actions = hot('-a-|', {
           a: DomainsCardsActions.increaseAvailableResources({ id: 'AAA' }),
         });
@@ -1006,31 +962,26 @@ describe('DomainsCardsEffects', () => {
     });
 
     describe('KO too many available resources', () => {
-      beforeEach(() => {
-        injector = Injector.create({
-          providers: [
-            provideMockStore({
-              selectors: [
-                {
-                  selector: DomainsCardsSelectors.getLandCardPivotById,
-                  value: {
-                    id: 'AAA',
-                    domainId: ID_DOMAIN_RED,
-                    cardType: LAND_CARD_INTERFACE_NAME,
-                    cardId: 'LAND_1',
-                    availableResources: 3,
-                    lockedResources: 0,
-                  },
-                },
-              ],
-            }),
-          ],
-        });
-        injector.get(MockStore);
-      });
-
       it(`should dispatch setDomainsCardsError
           with too many available resources error`, () => {
+        jest
+          .spyOn(DomainsCardsSelectors, 'getLandCardPivotById')
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          .mockImplementation((_id: string) =>
+            createSelector(
+              () => null,
+              () =>
+                ({
+                  id: 'AAA',
+                  domainId: ID_DOMAIN_RED,
+                  cardType: LAND_CARD_INTERFACE_NAME,
+                  cardId: 'LAND_1',
+                  availableResources: 3,
+                  lockedResources: 0,
+                } as DomainsCardsModels.DomainsCardsEntity | undefined)
+            )
+          );
+
         actions = hot('-a-|', {
           a: DomainsCardsActions.increaseAvailableResources({ id: 'AAA' }),
         });

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.ts
@@ -70,19 +70,17 @@ export class DomainsCardsEffects {
         return forkJoin({
           increaseOne: this.domainsCardsStore.pipe(
             select(
-              DomainsCardsSelectors.getLandCardsPivotsIncreaseOneProduction,
-              {
-                die: action.die,
-              }
+              DomainsCardsSelectors.getLandCardsPivotsIncreaseOneProduction(
+                action.die
+              )
             ),
             take(1)
           ),
           increaseTwo: this.domainsCardsStore.pipe(
             select(
-              DomainsCardsSelectors.getLandCardsPivotsIncreaseTwoProduction,
-              {
-                die: action.die,
-              }
+              DomainsCardsSelectors.getLandCardsPivotsIncreaseTwoProduction(
+                action.die
+              )
             ),
             take(1)
           ),
@@ -448,9 +446,7 @@ export class DomainsCardsEffects {
     id: string
   ): Observable<DomainsCardsEntity> {
     return this.domainsCardsStore.pipe(
-      select(DomainsCardsSelectors.getLandCardPivotById, {
-        id,
-      }),
+      select(DomainsCardsSelectors.getLandCardPivotById(id)),
       map((pivot) => {
         if (pivot === undefined) {
           throw new Error(`Couldn't find land card pivot for id.`);

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.effects.ts
@@ -2,11 +2,7 @@ import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { select, Store } from '@ngrx/store';
 import { fetch } from '@nrwl/angular';
-import {
-  ID_DOMAIN_BLUE,
-  ID_DOMAIN_RED,
-  landCards,
-} from '@taormina/shared-constants';
+import { landCards } from '@taormina/shared-constants';
 import {
   LandCard,
   ResourceCount,
@@ -102,31 +98,31 @@ export class DomainsCardsEffects {
       ofType(DomainsCardsActions.increaseAvailableResourcesForAuspiciousYear),
       withLatestFrom(
         this.domainsCardsStore.select(
-          DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear,
-          { count: 1 }
-        ),
-        this.domainsCardsStore.select(
-          DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear,
-          { count: 2 }
-        ),
-        this.domainsCardsStore.select(
-          DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear,
-          { count: 3 }
-        ),
-        this.domainsCardsStore.select(
-          DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear,
-          { count: 4 }
+          DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear
         )
       ),
       map(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        ([_action, increaseOne, increaseTwo, increaseThree, increaseFour]) => {
-          const updatesOne = this.updatesAvailableResources(increaseOne, 1);
-          /* eslint-disable no-magic-numbers */
-          const updatesTwo = this.updatesAvailableResources(increaseTwo, 2);
-          const updatesThree = this.updatesAvailableResources(increaseThree, 3);
-          const updatesFour = this.updatesAvailableResources(increaseFour, 4);
-          /* eslint-enable no-magic-numbers */
+        ([
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          _action,
+          [increaseOne, increaseTwo, increaseThree, increaseFour],
+        ]) => {
+          const updatesOne = this.updatesAvailableResources(
+            increaseOne,
+            DomainsCardsSelectors.COUNT_1
+          );
+          const updatesTwo = this.updatesAvailableResources(
+            increaseTwo,
+            DomainsCardsSelectors.COUNT_2
+          );
+          const updatesThree = this.updatesAvailableResources(
+            increaseThree,
+            DomainsCardsSelectors.COUNT_3
+          );
+          const updatesFour = this.updatesAvailableResources(
+            increaseFour,
+            DomainsCardsSelectors.COUNT_4
+          );
           return DomainsCardsActions.updateDomainsCards({
             updates: [
               ...updatesOne,
@@ -387,30 +383,18 @@ export class DomainsCardsEffects {
       ofType(DomainsCardsActions.countAndStealUnprotectedGoldAndWool),
       withLatestFrom(
         this.domainsCardsStore.select(
-          DomainsCardsSelectors.getDomainResourceCountSeenByThieves,
-          { domainId: ID_DOMAIN_RED }
+          DomainsCardsSelectors.getDomainResourceCountSeenByThieves
         ),
         this.domainsCardsStore.select(
-          DomainsCardsSelectors.getDomainResourceCountSeenByThieves,
-          { domainId: ID_DOMAIN_BLUE }
-        ),
-        this.domainsCardsStore.select(
-          DomainsCardsSelectors.getDomainUnprotectedGoldMinesAndPastures,
-          { domainId: ID_DOMAIN_RED }
-        ),
-        this.domainsCardsStore.select(
-          DomainsCardsSelectors.getDomainUnprotectedGoldMinesAndPastures,
-          { domainId: ID_DOMAIN_BLUE }
+          DomainsCardsSelectors.getDomainUnprotectedGoldMinesAndPastures
         )
       ),
       map(
         ([
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           _action,
-          redResourceCount,
-          blueResourceCount,
-          redGoldMinesAndPastures,
-          blueGoldMinesAndPastures,
+          [redResourceCount, blueResourceCount],
+          [redGoldMinesAndPastures, blueGoldMinesAndPastures],
         ]) => {
           const thievesResourceCountThreshold = 7;
           let pivots: DomainsCardsEntity[] = [];

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.facade.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.facade.ts
@@ -133,34 +133,26 @@ export class DomainsCardsFacade {
   }
 
   getDomainMinCol(domainId: string): Observable<number> {
-    return this.store.pipe(
-      select(DomainsCardsSelectors.getDomainMinCol, { domainId })
-    );
+    return this.store.select(DomainsCardsSelectors.getDomainMinCol(domainId));
   }
 
   getDomainMaxCol(domainId: string): Observable<number> {
-    return this.store.pipe(
-      select(DomainsCardsSelectors.getDomainMaxCol, { domainId })
-    );
+    return this.store.select(DomainsCardsSelectors.getDomainMaxCol(domainId));
   }
 
   getDomainMinRow(domainId: string): Observable<number> {
-    return this.store.pipe(
-      select(DomainsCardsSelectors.getDomainMinRow, { domainId })
-    );
+    return this.store.select(DomainsCardsSelectors.getDomainMinRow(domainId));
   }
 
   getDomainMaxRow(domainId: string): Observable<number> {
-    return this.store.pipe(
-      select(DomainsCardsSelectors.getDomainMaxRow, { domainId })
-    );
+    return this.store.select(DomainsCardsSelectors.getDomainMaxRow(domainId));
   }
 
   getMasteryDomainForType(
     type: MasteryPointsType
   ): Observable<string | undefined> {
-    return this.store.pipe(
-      select(DomainsCardsSelectors.getMasteryDomainForType, { type })
+    return this.store.select(
+      DomainsCardsSelectors.getMasteryDomainForType(type)
     );
   }
 

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
@@ -108,9 +108,8 @@ describe('DomainsCards Selectors', () => {
 
   describe('getLandCardPivotById({ id })', () => {
     it('should return the blue forest domain card', () => {
-      const result = DomainsCardsSelectors.getLandCardPivotById(state, {
-        id: blueForestId,
-      });
+      const result =
+        DomainsCardsSelectors.getLandCardPivotById(blueForestId)(state);
       const selId = getDomainsCardsId(result);
 
       expect(selId).toBe(blueForestId);
@@ -143,9 +142,8 @@ describe('DomainsCards Selectors', () => {
 
   describe('getDomainMinCol({ domainId })', () => {
     it('should return the lowest column number for the domain', () => {
-      const result = DomainsCardsSelectors.getDomainMinCol(state, {
-        domainId: ID_DOMAIN_BLUE,
-      });
+      const result =
+        DomainsCardsSelectors.getDomainMinCol(ID_DOMAIN_BLUE)(state);
 
       expect(result).toBe(-2);
     });
@@ -153,9 +151,8 @@ describe('DomainsCards Selectors', () => {
 
   describe('getDomainMaxCol({ domainId })', () => {
     it('should return the highest column number for the domain', () => {
-      const result = DomainsCardsSelectors.getDomainMaxCol(state, {
-        domainId: ID_DOMAIN_BLUE,
-      });
+      const result =
+        DomainsCardsSelectors.getDomainMaxCol(ID_DOMAIN_BLUE)(state);
 
       expect(result).toBe(2);
     });
@@ -163,9 +160,8 @@ describe('DomainsCards Selectors', () => {
 
   describe('getDomainMinRow({ domainId })', () => {
     it('should return the lowest row number for the domain', () => {
-      const result = DomainsCardsSelectors.getDomainMinRow(state, {
-        domainId: ID_DOMAIN_BLUE,
-      });
+      const result =
+        DomainsCardsSelectors.getDomainMinRow(ID_DOMAIN_BLUE)(state);
 
       expect(result).toBe(-1);
     });
@@ -173,9 +169,8 @@ describe('DomainsCards Selectors', () => {
 
   describe('getDomainMaxRow({ domainId })', () => {
     it('should return the highest row number for the domain', () => {
-      const result = DomainsCardsSelectors.getDomainMaxRow(state, {
-        domainId: ID_DOMAIN_BLUE,
-      });
+      const result =
+        DomainsCardsSelectors.getDomainMaxRow(ID_DOMAIN_BLUE)(state);
 
       expect(result).toBe(1);
     });
@@ -191,9 +186,9 @@ describe('DomainsCards Selectors', () => {
     describe('getLandCardsPivotsIncreaseOneProduction({ die })', () => {
       it('should return the red clay pit for die 3', () => {
         const results =
-          DomainsCardsSelectors.getLandCardsPivotsIncreaseOneProduction(state, {
-            die: 3,
-          });
+          DomainsCardsSelectors.getLandCardsPivotsIncreaseOneProduction(3)(
+            state
+          );
         const selId = getDomainsCardsId(results[0]);
 
         expect(selId).toBe(redClayPitId);
@@ -203,9 +198,9 @@ describe('DomainsCards Selectors', () => {
     describe('getLandCardsPivotsIncreaseTwoProduction({ die })', () => {
       it('should return the blue forest for die 3', () => {
         const results =
-          DomainsCardsSelectors.getLandCardsPivotsIncreaseTwoProduction(state, {
-            die: 3,
-          });
+          DomainsCardsSelectors.getLandCardsPivotsIncreaseTwoProduction(3)(
+            state
+          );
         const selId = getDomainsCardsId(results[0]);
 
         expect(selId).toBe(blueForestId);
@@ -223,9 +218,9 @@ describe('DomainsCards Selectors', () => {
         });
 
         it('should return undefined', () => {
-          const result = DomainsCardsSelectors.getMasteryDomainForType(state, {
-            type: MasteryPointsType.Trade,
-          });
+          const result = DomainsCardsSelectors.getMasteryDomainForType(
+            MasteryPointsType.Trade
+          )(state);
           expect(result).toBe(undefined);
         });
       });
@@ -238,9 +233,9 @@ describe('DomainsCards Selectors', () => {
         });
 
         it('should return undefined', () => {
-          const result = DomainsCardsSelectors.getMasteryDomainForType(state, {
-            type: MasteryPointsType.Trade,
-          });
+          const result = DomainsCardsSelectors.getMasteryDomainForType(
+            MasteryPointsType.Trade
+          )(state);
           expect(result).toBe(undefined);
         });
       });
@@ -253,9 +248,9 @@ describe('DomainsCards Selectors', () => {
         });
 
         it('should return the red domain id', () => {
-          const result = DomainsCardsSelectors.getMasteryDomainForType(state, {
-            type: MasteryPointsType.Trade,
-          });
+          const result = DomainsCardsSelectors.getMasteryDomainForType(
+            MasteryPointsType.Trade
+          )(state);
           expect(result).toBe(ID_DOMAIN_RED);
         });
       });
@@ -268,9 +263,9 @@ describe('DomainsCards Selectors', () => {
         });
 
         it('should return the blue domain id', () => {
-          const result = DomainsCardsSelectors.getMasteryDomainForType(state, {
-            type: MasteryPointsType.Trade,
-          });
+          const result = DomainsCardsSelectors.getMasteryDomainForType(
+            MasteryPointsType.Trade
+          )(state);
           expect(result).toBe(ID_DOMAIN_BLUE);
         });
       });
@@ -285,9 +280,9 @@ describe('DomainsCards Selectors', () => {
         });
 
         it('should return undefined', () => {
-          const result = DomainsCardsSelectors.getMasteryDomainForType(state, {
-            type: MasteryPointsType.Strength,
-          });
+          const result = DomainsCardsSelectors.getMasteryDomainForType(
+            MasteryPointsType.Strength
+          )(state);
           expect(result).toBe(undefined);
         });
       });
@@ -300,9 +295,9 @@ describe('DomainsCards Selectors', () => {
         });
 
         it('should return undefined', () => {
-          const result = DomainsCardsSelectors.getMasteryDomainForType(state, {
-            type: MasteryPointsType.Strength,
-          });
+          const result = DomainsCardsSelectors.getMasteryDomainForType(
+            MasteryPointsType.Strength
+          )(state);
           expect(result).toBe(undefined);
         });
       });
@@ -315,9 +310,9 @@ describe('DomainsCards Selectors', () => {
         });
 
         it('should return the red domain id', () => {
-          const result = DomainsCardsSelectors.getMasteryDomainForType(state, {
-            type: MasteryPointsType.Strength,
-          });
+          const result = DomainsCardsSelectors.getMasteryDomainForType(
+            MasteryPointsType.Strength
+          )(state);
           expect(result).toBe(ID_DOMAIN_RED);
         });
       });
@@ -330,9 +325,9 @@ describe('DomainsCards Selectors', () => {
         });
 
         it('should return the blue domain id', () => {
-          const result = DomainsCardsSelectors.getMasteryDomainForType(state, {
-            type: MasteryPointsType.Strength,
-          });
+          const result = DomainsCardsSelectors.getMasteryDomainForType(
+            MasteryPointsType.Strength
+          )(state);
           expect(result).toBe(ID_DOMAIN_BLUE);
         });
       });

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
@@ -342,51 +342,33 @@ describe('DomainsCards Selectors', () => {
     });
 
     describe('getDomainResourceCountSeenByThieves', () => {
-      it('should return 5 resources seen by thieves for the red domain', () => {
+      it(`should return 5 resources seen by thieves for the red domain
+          and 4 resources seen by thieves for the blue domain`, () => {
         const result =
-          DomainsCardsSelectors.getDomainResourceCountSeenByThieves(state, {
-            domainId: ID_DOMAIN_RED,
-          });
-        expect(result).toBe(5);
-      });
-
-      it('should return 4 resources seen by thieves for the blue domain', () => {
-        const result =
-          DomainsCardsSelectors.getDomainResourceCountSeenByThieves(state, {
-            domainId: ID_DOMAIN_BLUE,
-          });
-        expect(result).toBe(4);
+          DomainsCardsSelectors.getDomainResourceCountSeenByThieves(state);
+        expect(result.length).toBe(2);
+        expect(result[0]).toBe(5);
+        expect(result[1]).toBe(4);
       });
     });
 
     describe('getDomainUnprotectedGoldMinesAndPastures', () => {
-      it('should return the gold mine and the pasture for the red domain', () => {
+      it(`should return the gold mine and the pasture for the red domain
+          and only the pasture for the blue domain`, () => {
         const results =
-          DomainsCardsSelectors.getDomainUnprotectedGoldMinesAndPastures(
-            state,
-            {
-              domainId: ID_DOMAIN_RED,
-            }
-          );
-        const cardIdGoldMineRed = results[0]?.cardId;
-        const cardIdPastureRed = results[1]?.cardId;
-
+          DomainsCardsSelectors.getDomainUnprotectedGoldMinesAndPastures(state);
         expect(results.length).toBe(2);
+
+        const cardIdGoldMineRed = results[0][0]?.cardId;
+        const cardIdPastureRed = results[0][1]?.cardId;
+
+        expect(results[0].length).toBe(2);
         expect(cardIdGoldMineRed).toBe(ID_GOLD_MINE_RED);
         expect(cardIdPastureRed).toBe(ID_PASTURE_RED);
-      });
 
-      it('should return only the pasture for the blue domain', () => {
-        const results =
-          DomainsCardsSelectors.getDomainUnprotectedGoldMinesAndPastures(
-            state,
-            {
-              domainId: ID_DOMAIN_BLUE,
-            }
-          );
-        const cardIdPastureBlue = results[0]?.cardId;
+        const cardIdPastureBlue = results[1][0]?.cardId;
 
-        expect(results.length).toBe(1);
+        expect(results[1].length).toBe(1);
         expect(cardIdPastureBlue).toBe(ID_PASTURE_BLUE);
       });
     });
@@ -400,26 +382,24 @@ describe('DomainsCards Selectors', () => {
     });
     it('should return the clay pit and the pasture for the red domain with count 2', () => {
       const results =
-        DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear(state, {
-          count: 2,
-        });
-      const cardIdClayPitRed = results[0]?.cardId;
-      const cardIdPastureRed = results[1]?.cardId;
+        DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear(state);
+      const cardIdClayPitRed = results[1][0]?.cardId;
+      const cardIdPastureRed = results[1][1]?.cardId;
 
-      expect(results.length).toBe(2);
+      expect(results.length).toBe(4);
+      expect(results[1].length).toBe(2);
       expect(cardIdClayPitRed).toBe(ID_CLAY_PIT_RED);
       expect(cardIdPastureRed).toBe(ID_PASTURE_RED);
     });
 
     it('should return the forest and the gold mine for the blue domain with count 1', () => {
       const results =
-        DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear(state, {
-          count: 1,
-        });
-      const cardIdForestBlue = results[0]?.cardId;
-      const cardIdGoldMineBlue = results[1]?.cardId;
+        DomainsCardsSelectors.getLandCardsPivotsIncreaseAuspiciousYear(state);
+      const cardIdForestBlue = results[0][0]?.cardId;
+      const cardIdGoldMineBlue = results[0][1]?.cardId;
 
-      expect(results.length).toBe(2);
+      expect(results.length).toBe(4);
+      expect(results[0].length).toBe(2);
       expect(cardIdForestBlue).toBe(ID_FOREST_BLUE);
       expect(cardIdGoldMineBlue).toBe(ID_GOLD_MINE_BLUE);
     });

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
@@ -22,15 +22,14 @@ import {
 import { DomainsCardsEntity } from './domains-cards.models';
 import {
   domainsCardsAdapter,
-  DomainsCardsPartialState,
   DomainsCardsState,
   DOMAINS_CARDS_FEATURE_KEY,
 } from './domains-cards.reducer';
 
 // Lookup the 'DomainsCards' feature state managed by NgRx
-export const getDomainsCardsState = createFeatureSelector<
-  DomainsCardsState
->(DOMAINS_CARDS_FEATURE_KEY);
+export const getDomainsCardsState = createFeatureSelector<DomainsCardsState>(
+  DOMAINS_CARDS_FEATURE_KEY
+);
 
 const { selectAll, selectEntities } = domainsCardsAdapter.getSelectors();
 
@@ -111,22 +110,29 @@ const getLandCardFilterByDie = (
   return undefined;
 };
 
+export const COUNT_1 = 1;
+export const COUNT_2 = 2;
+export const COUNT_3 = 3;
+export const COUNT_4 = 4;
 export const getLandCardsPivotsIncreaseAuspiciousYear = createSelector(
   getAllDomainsCards,
-  (entities: DomainsCardsEntity[], props: { count: number }) =>
-    entities.filter((pivot) => {
-      if (
-        pivot.cardType === LAND_CARD_INTERFACE_NAME &&
-        pivot.cardId !== undefined
-      ) {
-        const land = landCards.get(pivot.cardId);
-        return (
-          land !== undefined &&
-          isNextToCountWarehouseOrMonastery(pivot, entities, props.count)
-        );
-      }
-      return false;
-    })
+  (entities: DomainsCardsEntity[]) => {
+    return [COUNT_1, COUNT_2, COUNT_3, COUNT_4].map((count) => {
+      return entities.filter((pivot) => {
+        if (
+          pivot.cardType === LAND_CARD_INTERFACE_NAME &&
+          pivot.cardId !== undefined
+        ) {
+          const land = landCards.get(pivot.cardId);
+          return (
+            land !== undefined &&
+            isNextToCountWarehouseOrMonastery(pivot, entities, count)
+          );
+        }
+        return false;
+      });
+    });
+  }
 );
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -255,33 +261,39 @@ const fromPointsToMastery = (
 
 export const getDomainResourceCountSeenByThieves = createSelector(
   getAllDomainsCards,
-  (entities: DomainsCardsEntity[], props: { domainId: string }) =>
-    entities
-      .filter(
-        (pivot) =>
-          pivot.domainId === props.domainId &&
-          pivot.cardType === LAND_CARD_INTERFACE_NAME &&
-          !isNextToAWarehouse(pivot, entities)
-      )
-      .reduce(
-        (accumulator, domainCard) =>
-          accumulator + domainCard.availableResources,
-        0
-      )
+  (entities: DomainsCardsEntity[]) => {
+    return [ID_DOMAIN_RED, ID_DOMAIN_BLUE].map((domainId) => {
+      return entities
+        .filter(
+          (pivot) =>
+            pivot.domainId === domainId &&
+            pivot.cardType === LAND_CARD_INTERFACE_NAME &&
+            !isNextToAWarehouse(pivot, entities)
+        )
+        .reduce(
+          (accumulator, domainCard) =>
+            accumulator + domainCard.availableResources,
+          0
+        );
+    });
+  }
 );
 
 export const getDomainUnprotectedGoldMinesAndPastures = createSelector(
   getAllDomainsCards,
-  (entities: DomainsCardsEntity[], props: { domainId: string }) =>
-    entities.filter(
-      (pivot) =>
-        pivot.domainId === props.domainId &&
-        pivot.cardType === LAND_CARD_INTERFACE_NAME &&
-        pivot.cardId !== undefined &&
-        (landCards.get(pivot.cardId)?.type === LandType.GoldMine ||
-          landCards.get(pivot.cardId)?.type === LandType.Pasture) &&
-        !isNextToAWarehouse(pivot, entities)
-    )
+  (entities: DomainsCardsEntity[]) => {
+    return [ID_DOMAIN_RED, ID_DOMAIN_BLUE].map((domainId) => {
+      return entities.filter(
+        (pivot) =>
+          pivot.domainId === domainId &&
+          pivot.cardType === LAND_CARD_INTERFACE_NAME &&
+          pivot.cardId !== undefined &&
+          (landCards.get(pivot.cardId)?.type === LandType.GoldMine ||
+            landCards.get(pivot.cardId)?.type === LandType.Pasture) &&
+          !isNextToAWarehouse(pivot, entities)
+      );
+    });
+  }
 );
 
 const isNextToAProductionBuilding = (
@@ -389,6 +401,7 @@ export const getCardsVictoryPointsForDomain = (domainId: string) =>
       .reduce((accumulator, currentValue) => accumulator + currentValue, 0);
   });
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const getMerchantShipCountForDomain = (domainId: string) =>
   createSelector(
     getAllDomainsCards,
@@ -408,6 +421,7 @@ export const getMerchantShipCountForDomain = (domainId: string) =>
         ).length
   );
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const getCelebrationPointsForDomain = (domainId: string) =>
   createSelector(getAllDomainsCards, (entities: DomainsCardsEntity[]) =>
     entities
@@ -426,6 +440,7 @@ export const getCelebrationPointsForDomain = (domainId: string) =>
       .reduce((accumulator, currentValue) => accumulator + currentValue, 0)
   );
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const hasDomainCommunityCenter = (domainId: string) =>
   createSelector(
     getAllDomainsCards,

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { createFeatureSelector, createSelector } from '@ngrx/store';
 import {
   agglomerationCards,
@@ -72,29 +71,29 @@ export const getDomainsCardsSelected = createSelector(
   }
 );
 
-export const getLandCardsPivotsIncreaseOneProduction = createSelector(
-  getAllDomainsCards,
-  (entities: DomainsCardsEntity[], props: { die: ResourceValue }) =>
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const getLandCardsPivotsIncreaseOneProduction = (die: ResourceValue) =>
+  createSelector(getAllDomainsCards, (entities: DomainsCardsEntity[]) =>
     entities.filter((pivot) => {
-      const land = getLandCardFilterByDie(pivot, props.die);
+      const land = getLandCardFilterByDie(pivot, die);
       return (
         land !== undefined &&
         !isNextToAProductionBuilding(pivot, entities, land.type)
       );
     })
-);
+  );
 
-export const getLandCardsPivotsIncreaseTwoProduction = createSelector(
-  getAllDomainsCards,
-  (entities: DomainsCardsEntity[], props: { die: ResourceValue }) =>
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const getLandCardsPivotsIncreaseTwoProduction = (die: ResourceValue) =>
+  createSelector(getAllDomainsCards, (entities: DomainsCardsEntity[]) =>
     entities.filter((pivot) => {
-      const land = getLandCardFilterByDie(pivot, props.die);
+      const land = getLandCardFilterByDie(pivot, die);
       return (
         land !== undefined &&
         isNextToAProductionBuilding(pivot, entities, land.type)
       );
     })
-);
+  );
 
 const getLandCardFilterByDie = (
   pivot: DomainsCardsEntity,
@@ -130,14 +129,13 @@ export const getLandCardsPivotsIncreaseAuspiciousYear = createSelector(
     })
 );
 
-export const getLandCardPivotById = createSelector(
-  getAllDomainsCards,
-  (entities: DomainsCardsEntity[], props: { id: string }) =>
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const getLandCardPivotById = (id: string) =>
+  createSelector(getAllDomainsCards, (entities: DomainsCardsEntity[]) =>
     entities.find(
-      (pivot) =>
-        pivot.cardType === LAND_CARD_INTERFACE_NAME && pivot.id === props.id
+      (pivot) => pivot.cardType === LAND_CARD_INTERFACE_NAME && pivot.id === id
     )
-);
+  );
 
 export const getLandCardPivotWithLockedResources = createSelector(
   getAllDomainsCards,
@@ -148,49 +146,49 @@ export const getLandCardPivotWithLockedResources = createSelector(
     )
 );
 
-export const getDomainMinCol = createSelector(
-  getAllDomainsCards,
-  (entities: DomainsCardsEntity[], props: { domainId: string }) =>
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const getDomainMinCol = (domainId: string) =>
+  createSelector(getAllDomainsCards, (entities: DomainsCardsEntity[]) =>
     Math.min(
       ...entities
-        .filter((pivot) => pivot.domainId === props.domainId)
+        .filter((pivot) => pivot.domainId === domainId)
         .map((pivot) => pivot.col)
     )
-);
+  );
 
-export const getDomainMaxCol = createSelector(
-  getAllDomainsCards,
-  (entities: DomainsCardsEntity[], props: { domainId: string }) =>
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const getDomainMaxCol = (domainId: string) =>
+  createSelector(getAllDomainsCards, (entities: DomainsCardsEntity[]) =>
     Math.max(
       ...entities
-        .filter((pivot) => pivot.domainId === props.domainId)
+        .filter((pivot) => pivot.domainId === domainId)
         .map((pivot) => pivot.col)
     )
-);
+  );
 
-export const getDomainMinRow = createSelector(
-  getAllDomainsCards,
-  (entities: DomainsCardsEntity[], props: { domainId: string }) =>
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const getDomainMinRow = (domainId: string) =>
+  createSelector(getAllDomainsCards, (entities: DomainsCardsEntity[]) =>
     Math.min(
       ...entities
-        .filter((pivot) => pivot.domainId === props.domainId)
+        .filter((pivot) => pivot.domainId === domainId)
         .map((pivot) => pivot.row)
     )
-);
+  );
 
-export const getDomainMaxRow = createSelector(
-  getAllDomainsCards,
-  (entities: DomainsCardsEntity[], props: { domainId: string }) =>
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const getDomainMaxRow = (domainId: string) =>
+  createSelector(getAllDomainsCards, (entities: DomainsCardsEntity[]) =>
     Math.max(
       ...entities
-        .filter((pivot) => pivot.domainId === props.domainId)
+        .filter((pivot) => pivot.domainId === domainId)
         .map((pivot) => pivot.row)
     )
-);
+  );
 
-export const getMasteryDomainForType = createSelector(
-  getAllDomainsCards,
-  (entities: DomainsCardsEntity[], props: { type: MasteryPointsType }) => {
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const getMasteryDomainForType = (type: MasteryPointsType) =>
+  createSelector(getAllDomainsCards, (entities: DomainsCardsEntity[]) => {
     const redDomainCards = entities.filter(
       (pivot) => pivot.domainId === ID_DOMAIN_RED
     );
@@ -198,12 +196,11 @@ export const getMasteryDomainForType = createSelector(
       (pivot) => pivot.domainId === ID_DOMAIN_BLUE
     );
 
-    const redTradePoints = accPointsForType(redDomainCards, props.type);
-    const blueTradePoints = accPointsForType(blueDomainCards, props.type);
+    const redTradePoints = accPointsForType(redDomainCards, type);
+    const blueTradePoints = accPointsForType(blueDomainCards, type);
 
     return fromPointsToMastery(redTradePoints, blueTradePoints);
-  }
-);
+  });
 
 const getDevelopmentCardPointsForType = (
   developmentCard: DevelopmentCard,
@@ -367,6 +364,7 @@ const getCardSideNeighbors = (
       (pivot.row < 0 ? domainCard.row < 0 : domainCard.row >= 0)
   );
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const getCardsVictoryPointsForDomain = (domainId: string) =>
   createSelector(getAllDomainsCards, (entities) => {
     return entities

--- a/libs/data-access-game/src/lib/+state/events-pile-cards/events-pile-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/events-pile-cards/events-pile-cards.selectors.ts
@@ -2,14 +2,12 @@ import { createFeatureSelector, createSelector } from '@ngrx/store';
 import {
   EVENTS_PILE_CARDS_FEATURE_KEY,
   EventsPileCardsState,
-  EventsPileCardsPartialState,
   eventsPileCardsAdapter,
 } from './events-pile-cards.reducer';
 
 // Lookup the 'EventsPileCards' feature state managed by NgRx
-export const getEventsPileCardsState = createFeatureSelector<
-  EventsPileCardsState
->(EVENTS_PILE_CARDS_FEATURE_KEY);
+export const getEventsPileCardsState =
+  createFeatureSelector<EventsPileCardsState>(EVENTS_PILE_CARDS_FEATURE_KEY);
 
 const { selectAll, selectEntities } = eventsPileCardsAdapter.getSelectors();
 

--- a/libs/data-access-game/src/lib/+state/face-up-piles-cards/face-up-piles-cards.effects.ts
+++ b/libs/data-access-game/src/lib/+state/face-up-piles-cards/face-up-piles-cards.effects.ts
@@ -47,9 +47,9 @@ export class FaceUpPilesCardsEffects {
       ofType(FaceUpPilesCardsActions.selectFirstCardFromFaceUpPile),
       concatMap((action) =>
         this.faceUpPilesCardsStore.pipe(
-          select(FaceUpPilesCardsSelectors.getFirstCardPivotForPile, {
-            pileId: action.pileId,
-          }),
+          select(
+            FaceUpPilesCardsSelectors.getFirstCardPivotForPile(action.pileId)
+          ),
           map((pivot) => {
             if (pivot === undefined) {
               throw new Error(`Can't get first card in empty face up pile.`);

--- a/libs/data-access-game/src/lib/+state/face-up-piles-cards/face-up-piles-cards.facade.ts
+++ b/libs/data-access-game/src/lib/+state/face-up-piles-cards/face-up-piles-cards.facade.ts
@@ -25,20 +25,14 @@ export class FaceUpPilesCardsFacade {
   selectedFaceUpPilesCards$ = this.store.pipe(
     select(FaceUpPilesCardsSelectors.getFaceUpSelected)
   );
-  allRoadPivots$ = this.store.pipe(
-    select(FaceUpPilesCardsSelectors.getCardPivotsForPile, {
-      pileId: ID_FACE_UP_ROAD,
-    })
+  allRoadPivots$ = this.store.select(
+    FaceUpPilesCardsSelectors.getCardPivotsForPile(ID_FACE_UP_ROAD)
   );
-  allHamletPivots$ = this.store.pipe(
-    select(FaceUpPilesCardsSelectors.getCardPivotsForPile, {
-      pileId: ID_FACE_UP_HAMLET,
-    })
+  allHamletPivots$ = this.store.select(
+    FaceUpPilesCardsSelectors.getCardPivotsForPile(ID_FACE_UP_HAMLET)
   );
-  allTownPivots$ = this.store.pipe(
-    select(FaceUpPilesCardsSelectors.getCardPivotsForPile, {
-      pileId: ID_FACE_UP_TOWN,
-    })
+  allTownPivots$ = this.store.select(
+    FaceUpPilesCardsSelectors.getCardPivotsForPile(ID_FACE_UP_TOWN)
   );
 
   constructor(

--- a/libs/data-access-game/src/lib/+state/face-up-piles-cards/face-up-piles-cards.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/face-up-piles-cards/face-up-piles-cards.selectors.spec.ts
@@ -78,12 +78,9 @@ describe('FaceUpPilesCards Selectors', () => {
   describe('getFaceUpPileCardEntityByPivot({ pileId, cardId })', () => {
     it('should return the pivot for the pileId and cardId', () => {
       const result = FaceUpPilesCardsSelectors.getFaceUpPileCardEntityByPivot(
-        state,
-        {
-          pileId: 'B',
-          cardId: 'B',
-        }
-      );
+        'B',
+        'B'
+      )(state);
       const selId = getFaceUpPilesCardsId(result);
 
       expect(selId).toBe('PRODUCT-BBB');
@@ -92,9 +89,8 @@ describe('FaceUpPilesCards Selectors', () => {
 
   describe('getCardPivotsForPile({ pileId })', () => {
     it('should return the pivots for the pileId', () => {
-      const results = FaceUpPilesCardsSelectors.getCardPivotsForPile(state, {
-        pileId: 'B',
-      });
+      const results =
+        FaceUpPilesCardsSelectors.getCardPivotsForPile('B')(state);
       const selId = getFaceUpPilesCardsId(results[1]);
 
       expect(results.length).toBe(2);
@@ -104,9 +100,8 @@ describe('FaceUpPilesCards Selectors', () => {
 
   describe('getFirstCardPivotForPile({ pileId })', () => {
     it('should return the first pivot for the pileId', () => {
-      const result = FaceUpPilesCardsSelectors.getFirstCardPivotForPile(state, {
-        pileId: 'B',
-      });
+      const result =
+        FaceUpPilesCardsSelectors.getFirstCardPivotForPile('B')(state);
       const selId = getFaceUpPilesCardsId(result);
 
       expect(selId).toBe('PRODUCT-BBB');

--- a/libs/data-access-game/src/lib/+state/face-up-piles-cards/face-up-piles-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/face-up-piles-cards/face-up-piles-cards.selectors.ts
@@ -49,26 +49,25 @@ export const getFaceUpSelected = createSelector(
   }
 );
 
-export const getFaceUpPileCardEntityByPivot = createSelector(
-  getAllFaceUpPilesCards,
-  (
-    entities: FaceUpPilesCardsEntity[],
-    props: { pileId: string; cardId: string }
-  ) =>
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const getFaceUpPileCardEntityByPivot = (
+  pileId: string,
+  cardId: string
+) =>
+  createSelector(getAllFaceUpPilesCards, (entities: FaceUpPilesCardsEntity[]) =>
     entities.find(
-      (entity) =>
-        entity.pileId === props.pileId && entity.cardId === props.cardId
+      (entity) => entity.pileId === pileId && entity.cardId === cardId
     )
-);
+  );
 
-export const getCardPivotsForPile = createSelector(
-  getAllFaceUpPilesCards,
-  (entities: FaceUpPilesCardsEntity[], props: { pileId: string }) =>
-    entities.filter((pivot) => pivot.pileId === props.pileId)
-);
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const getCardPivotsForPile = (pileId: string) =>
+  createSelector(getAllFaceUpPilesCards, (entities: FaceUpPilesCardsEntity[]) =>
+    entities.filter((pivot) => pivot.pileId === pileId)
+  );
 
-export const getFirstCardPivotForPile = createSelector(
-  getAllFaceUpPilesCards,
-  (entities: FaceUpPilesCardsEntity[], props: { pileId: string }) =>
-    entities.find((pivot) => pivot.pileId === props.pileId)
-);
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const getFirstCardPivotForPile = (pileId: string) =>
+  createSelector(getAllFaceUpPilesCards, (entities: FaceUpPilesCardsEntity[]) =>
+    entities.find((pivot) => pivot.pileId === pileId)
+  );

--- a/libs/data-access-game/src/lib/+state/face-up-piles-cards/face-up-piles-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/face-up-piles-cards/face-up-piles-cards.selectors.ts
@@ -3,15 +3,13 @@ import { createFeatureSelector, createSelector } from '@ngrx/store';
 import { FaceUpPilesCardsEntity } from './face-up-piles-cards.models';
 import {
   faceUpPilesCardsAdapter,
-  FaceUpPilesCardsPartialState,
   FaceUpPilesCardsState,
   FACE_UP_PILES_CARDS_FEATURE_KEY,
 } from './face-up-piles-cards.reducer';
 
 // Lookup the 'FaceUpPilesCards' feature state managed by NgRx
-export const getFaceUpPilesCardsState = createFeatureSelector<
-  FaceUpPilesCardsState
->(FACE_UP_PILES_CARDS_FEATURE_KEY);
+export const getFaceUpPilesCardsState =
+  createFeatureSelector<FaceUpPilesCardsState>(FACE_UP_PILES_CARDS_FEATURE_KEY);
 
 const { selectAll, selectEntities } = faceUpPilesCardsAdapter.getSelectors();
 

--- a/libs/data-access-game/src/lib/+state/game/game.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/game/game.selectors.ts
@@ -1,9 +1,8 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
-import { GamePartialState, GameState, GAME_FEATURE_KEY } from './game.reducer';
+import { GameState, GAME_FEATURE_KEY } from './game.reducer';
 
 // Lookup the 'Game' feature state managed by NgRx
-export const getGameState =
-  createFeatureSelector< GameState>(GAME_FEATURE_KEY);
+export const getGameState = createFeatureSelector<GameState>(GAME_FEATURE_KEY);
 
 export const getGameProductionDie = createSelector(
   getGameState,

--- a/libs/data-access-game/src/lib/+state/hands-cards/hands-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/hands-cards/hands-cards.selectors.ts
@@ -2,14 +2,13 @@ import { createFeatureSelector, createSelector } from '@ngrx/store';
 import {
   HANDS_CARDS_FEATURE_KEY,
   HandsCardsState,
-  HandsCardsPartialState,
   handsCardsAdapter,
 } from './hands-cards.reducer';
 
 // Lookup the 'HandsCards' feature state managed by NgRx
-export const getHandsCardsState = createFeatureSelector<
-  HandsCardsState
->(HANDS_CARDS_FEATURE_KEY);
+export const getHandsCardsState = createFeatureSelector<HandsCardsState>(
+  HANDS_CARDS_FEATURE_KEY
+);
 
 const { selectAll, selectEntities } = handsCardsAdapter.getSelectors();
 

--- a/libs/data-access-game/src/lib/+state/lands-pile-cards/lands-pile-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/lands-pile-cards/lands-pile-cards.selectors.ts
@@ -2,14 +2,12 @@ import { createFeatureSelector, createSelector } from '@ngrx/store';
 import {
   LANDS_PILE_CARDS_FEATURE_KEY,
   LandsPileCardsState,
-  LandsPileCardsPartialState,
   landsPileCardsAdapter,
 } from './lands-pile-cards.reducer';
 
 // Lookup the 'LandsPileCards' feature state managed by NgRx
-export const getLandsPileCardsState = createFeatureSelector<
-  LandsPileCardsState
->(LANDS_PILE_CARDS_FEATURE_KEY);
+export const getLandsPileCardsState =
+  createFeatureSelector<LandsPileCardsState>(LANDS_PILE_CARDS_FEATURE_KEY);
 
 const { selectAll, selectEntities } = landsPileCardsAdapter.getSelectors();
 

--- a/libs/data-access-game/src/lib/+state/stock-piles-cards/stock-piles-cards.effects.spec.ts
+++ b/libs/data-access-game/src/lib/+state/stock-piles-cards/stock-piles-cards.effects.spec.ts
@@ -1,8 +1,7 @@
-import { Injector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { Action } from '@ngrx/store';
-import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { Action, createSelector } from '@ngrx/store';
+import { provideMockStore } from '@ngrx/store/testing';
 import { DataPersistence, NxModule } from '@nrwl/angular';
 import { hot } from 'jasmine-marbles';
 import { ACTION_CARD_INTERFACE_NAME } from '@taormina/shared-models';
@@ -21,7 +20,6 @@ jest.mock('uuid', () => {
 });
 
 describe('StockPilesCardsEffects', () => {
-  let injector: Injector;
   let actions: Observable<Action>;
   let effects: StockPilesCardsEffects;
 
@@ -76,29 +74,25 @@ describe('StockPilesCardsEffects', () => {
   });
 
   describe('removeCards$', () => {
-    beforeEach(() => {
-      injector = Injector.create({
-        providers: [
-          provideMockStore({
-            selectors: [
-              {
-                selector:
-                  StockPilesCardsSelectors.getStockPileCardEntityByPivot,
-                value: {
-                  id: 'AAA',
-                  pileId: 'A',
-                  cardType: ACTION_CARD_INTERFACE_NAME,
-                  cardId: 'A',
-                },
-              },
-            ],
-          }),
-        ],
-      });
-      injector.get(MockStore);
-    });
-
     it('should dispatch removeStockPilesCards', () => {
+      const expectedId = 'AAA';
+      jest
+        .spyOn(StockPilesCardsSelectors, 'getStockPileCardEntityByPivot')
+        .mockImplementation(
+          (pileId: string, cardType: string, cardId: string) =>
+            createSelector(
+              () => [],
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              (_) =>
+                ({
+                  id: expectedId,
+                  pileId,
+                  cardType,
+                  cardId,
+                } as StockPilesCardsModels.StockPilesCardsEntity | undefined)
+            )
+        );
+
       actions = hot('-a-|', {
         a: StockPilesCardsActions.removeCardsFromStockPileTop({
           pileId: 'A',
@@ -108,7 +102,7 @@ describe('StockPilesCardsEffects', () => {
 
       const expected = hot('-a-|', {
         a: StockPilesCardsActions.removeStockPilesCards({
-          ids: ['AAA'],
+          ids: [expectedId],
         }),
       });
 

--- a/libs/data-access-game/src/lib/+state/stock-piles-cards/stock-piles-cards.effects.ts
+++ b/libs/data-access-game/src/lib/+state/stock-piles-cards/stock-piles-cards.effects.ts
@@ -54,11 +54,13 @@ export class StockPilesCardsEffects {
         forkJoin(
           action.cards.map(({ type: cardType, id: cardId }) =>
             this.stockPilesCardsStore.pipe(
-              select(StockPilesCardsSelectors.getStockPileCardEntityByPivot, {
-                pileId: action.pileId,
-                cardType,
-                cardId,
-              }),
+              select(
+                StockPilesCardsSelectors.getStockPileCardEntityByPivot(
+                  action.pileId,
+                  cardType,
+                  cardId
+                )
+              ),
               take(1)
             )
           )

--- a/libs/data-access-game/src/lib/+state/stock-piles-cards/stock-piles-cards.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/stock-piles-cards/stock-piles-cards.selectors.spec.ts
@@ -99,9 +99,10 @@ describe('StockPilesCards Selectors', () => {
       const cardType = ACTION_CARD_INTERFACE_NAME;
       const cardId = 'F';
       const result = StockPilesCardsSelectors.getStockPileCardEntityByPivot(
-        state,
-        { pileId, cardType, cardId }
-      );
+        pileId,
+        cardType,
+        cardId
+      )(state);
       const selId = getStockPilesCardsId(result);
 
       expect(selId).toBe('PRODUCT-CCC');

--- a/libs/data-access-game/src/lib/+state/stock-piles-cards/stock-piles-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/stock-piles-cards/stock-piles-cards.selectors.ts
@@ -48,16 +48,17 @@ export const getStockPilesCardsSelected = createSelector(
   }
 );
 
-export const getStockPileCardEntityByPivot = createSelector(
-  getAllStockPilesCards,
-  (
-    entities: StockPilesCardsEntity[],
-    props: { pileId: string; cardType: string; cardId: string }
-  ) =>
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const getStockPileCardEntityByPivot = (
+  pileId: string,
+  cardType: string,
+  cardId: string
+) =>
+  createSelector(getAllStockPilesCards, (entities: StockPilesCardsEntity[]) =>
     entities.find(
       (entity) =>
-        entity.pileId === props.pileId &&
-        entity.cardType === props.cardType &&
-        entity.cardId === props.cardId
+        entity.pileId === pileId &&
+        entity.cardType === cardType &&
+        entity.cardId === cardId
     )
-);
+  );

--- a/libs/data-access-game/src/lib/+state/stock-piles-cards/stock-piles-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/stock-piles-cards/stock-piles-cards.selectors.ts
@@ -3,14 +3,12 @@ import { StockPilesCardsEntity } from './stock-piles-cards.models';
 import {
   STOCK_PILES_CARDS_FEATURE_KEY,
   StockPilesCardsState,
-  StockPilesCardsPartialState,
   stockPilesCardsAdapter,
 } from './stock-piles-cards.reducer';
 
 // Lookup the 'StockPilesCards' feature state managed by NgRx
-export const getStockPilesCardsState = createFeatureSelector<
-  StockPilesCardsState
->(STOCK_PILES_CARDS_FEATURE_KEY);
+export const getStockPilesCardsState =
+  createFeatureSelector<StockPilesCardsState>(STOCK_PILES_CARDS_FEATURE_KEY);
 
 const { selectAll, selectEntities } = stockPilesCardsAdapter.getSelectors();
 


### PR DESCRIPTION
### Description
As explained here https://github.com/ngrx/platform/issues/2980, selectors with properties are deprecated and should be replaced by selector factories.
Here is a discussion on how to mock those with Jest: https://github.com/ngrx/platform/issues/3107#issuecomment-892998629

https://lhbruneton.atlassian.net/browse/TAOR-52

### Checklist
- [x] Created tests with given/when/then blocks
- [x] Created tests for the nominal use case
- [x] Created tests for errors
- [x] Build project without errors
