### PR TITLE
TAOR-20: Observe merchant ships count

### DIFF
--- a/apps/taormina-duel/src/app/app.component.html
+++ b/apps/taormina-duel/src/app/app.component.html
@@ -322,6 +322,7 @@
       - Strength Mastery</span
     >
     <span> - Victory points: {{ getVictoryPoints(domain.id) | async }}</span>
+    <span> - Ships count: {{ getShipsCount(domain.id) | async }}</span>
   </div>
   <div
     class="grid-container"
@@ -420,6 +421,7 @@
       - Strength Mastery</span
     >
     <span> - Victory points: {{ getVictoryPoints(domain.id) | async }}</span>
+    <span> - Ships count: {{ getShipsCount(domain.id) | async }}</span>
   </div>
   <div
     class="grid-container"

--- a/apps/taormina-duel/src/app/app.component.ts
+++ b/apps/taormina-duel/src/app/app.component.ts
@@ -187,6 +187,10 @@ export class AppComponent {
     return this.gameRules.getVictoryPointsForDomain(domainId);
   }
 
+  getShipsCount(domainId: string): Observable<number> {
+    return this.domainsCards.getMerchantShipCountForDomain(domainId);
+  }
+
   getColumnsTemplate(domainId: string): Observable<string> {
     return combineLatest([
       this.domainsCards.getDomainMinCol(domainId),

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.facade.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.facade.ts
@@ -161,4 +161,10 @@ export class DomainsCardsFacade {
       DomainsCardsSelectors.getCardsVictoryPointsForDomain(domainId)
     );
   }
+
+  getMerchantShipCountForDomain(domainId: string): Observable<number> {
+    return this.store.select(
+      DomainsCardsSelectors.getMerchantShipCountForDomain(domainId)
+    );
+  }
 }

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.spec.ts
@@ -24,6 +24,7 @@ import {
   domainsCardsThreeStrengthRedThreeStrengthBlueState,
   domainsCardsThreeTradeRedFourTradeBlueState,
   domainsCardsThreeTradeRedThreeTradeBlueState,
+  domainsCardsTwoShipsRedState,
   domainsCardsWarehouseNextToBlueForestState,
   redClayPitDomainCard,
   redClayPitId,
@@ -436,6 +437,22 @@ describe('DomainsCards Selectors', () => {
     it('should return two victory points for the two initial hamlets', () => {
       const result =
         DomainsCardsSelectors.getCardsVictoryPointsForDomain(ID_DOMAIN_RED)(
+          state
+        );
+
+      expect(result).toBe(2);
+    });
+  });
+
+  describe('getMerchantShipCountForDomain()', () => {
+    beforeEach(() => {
+      state = {
+        domainsCards: domainsCardsTwoShipsRedState(),
+      };
+    });
+    it('should return a two ships count for the red domain', () => {
+      const result =
+        DomainsCardsSelectors.getMerchantShipCountForDomain(ID_DOMAIN_RED)(
           state
         );
 

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.selectors.ts
@@ -11,6 +11,7 @@ import {
   AGGLOMERATION_CARD_INTERFACE_NAME,
   BuildingName,
   DevelopmentCard,
+  DevelopmentType,
   DEVELOPMENT_CARD_INTERFACE_NAME,
   DiceValue,
   LandCard,
@@ -390,3 +391,22 @@ export const getCardsVictoryPointsForDomain = (domainId: string) =>
       })
       .reduce((accumulator, currentValue) => accumulator + currentValue, 0);
   });
+
+export const getMerchantShipCountForDomain = (domainId: string) =>
+  createSelector(
+    getAllDomainsCards,
+    (entities: DomainsCardsEntity[]) =>
+      entities
+        .filter(
+          (pivot) => pivot.domainId === domainId && pivot.cardId !== undefined
+        )
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        .map((pivot) => developmentCards.get(pivot.cardId!))
+        .filter(
+          (developmentCard): developmentCard is DevelopmentCard =>
+            developmentCard !== undefined
+        )
+        .filter(
+          (developmentCard) => developmentCard.type === DevelopmentType.Ship
+        ).length
+  );

--- a/libs/data-access-game/src/test/fixtures/domains-cards.ts
+++ b/libs/data-access-game/src/test/fixtures/domains-cards.ts
@@ -782,3 +782,39 @@ export const domainsCardsSwappedForestAndStoneQuarryRedState =
     };
     return domainsCards;
   };
+
+export const domainsCardsTwoShipsRedState = (): DomainsCardsState => {
+  const newIds = (domainsCardsNewGameState.ids as string[]).filter(
+    (id) =>
+      id !== redAvailableDevelopmentSlotOneId &&
+      id !== redAvailableDevelopmentSlotTwoId
+  );
+  const newEntities = { ...domainsCardsNewGameState.entities };
+  delete newEntities[redAvailableDevelopmentSlotOneId];
+  delete newEntities[redAvailableDevelopmentSlotTwoId];
+
+  const domainsCards = {
+    ...domainsCardsNewGameState,
+    ids: [...newIds, 'aaaa', 'bbbb'],
+    entities: {
+      ...newEntities,
+      aaaa: createDomainsCardsEntity(
+        'aaaa',
+        ID_DOMAIN_RED,
+        DEVELOPMENT_CARD_INTERFACE_NAME,
+        'SHIP_1',
+        -1,
+        1
+      ),
+      bbbb: createDomainsCardsEntity(
+        'bbbb',
+        ID_DOMAIN_RED,
+        DEVELOPMENT_CARD_INTERFACE_NAME,
+        'SHIP_2',
+        1,
+        1
+      ),
+    },
+  };
+  return domainsCards;
+};


### PR DESCRIPTION
### Description
Get and display ships count for each domain. Much the same as victory points and mastery.

https://lhbruneton.atlassian.net/browse/TAOR-20

### Checklist
- [ ] Created tests with given/when/then blocks
- [x] Created tests for the nominal use case
- [ ] Created tests for errors
- [x] Build project without errors
