### PR TITLE
TAOR-17: Use locked resources to put in selected land card

### DIFF
--- a/apps/taormina-duel/src/app/app.component.html
+++ b/apps/taormina-duel/src/app/app.component.html
@@ -181,6 +181,9 @@
 <hr />
 <div class="flex-container">
   <button type="button" (click)="putLand()">put land</button>
+  <button type="button" (click)="giveLockedResources()">
+    Give locked resources
+  </button>
   <div>
     <p>Pile Selected Land Card:</p>
     <p *ngIf="getPileSelectedLandCard() | async as pivot">

--- a/apps/taormina-duel/src/app/app.component.ts
+++ b/apps/taormina-duel/src/app/app.component.ts
@@ -511,6 +511,10 @@ export class AppComponent {
     this.gameRules.putLandsPileCardInSlot();
   }
 
+  giveLockedResources(): void {
+    this.domainsCards.giveLockedResources();
+  }
+
   getSelectedFaceUpPileCard(): Observable<FaceUpPilesCardsEntity | undefined> {
     return this.faceUpPilesCards.selectedFaceUpPilesCards$;
   }

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.actions.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.actions.ts
@@ -74,6 +74,10 @@ export const useLockedResources = createAction(
   '[DomainsCards] Use Locked Resources'
 );
 
+export const giveLockedResources = createAction(
+  '[DomainsCards] Give Locked Resources'
+);
+
 export const toggleDomainCardSelection = createAction(
   '[DomainsCards] Toggle DomainCard Selection',
   props<{ id: string }>()

--- a/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.facade.ts
+++ b/libs/data-access-game/src/lib/+state/domains-cards/domains-cards.facade.ts
@@ -73,6 +73,10 @@ export class DomainsCardsFacade {
     this.store.dispatch(DomainsCardsActions.useLockedResources());
   }
 
+  giveLockedResources(): void {
+    this.store.dispatch(DomainsCardsActions.giveLockedResources());
+  }
+
   toggleDomainCardSelection(pivotId: string): void {
     this.store.dispatch(
       DomainsCardsActions.toggleDomainCardSelection({ id: pivotId })


### PR DESCRIPTION
### Description
When locked resources of the same type do not exceed the available resources capacity of a single selected land card of the same type, give locked resources to the selected land card.

https://lhbruneton.atlassian.net/browse/TAOR-17

### Checklist
- [ ] Created tests with given/when/then blocks
- [X] Created tests for the nominal use case
- [X] Created tests for errors
- [X] Build project without errors
