### PR TITLE
Add not empty app css file

### DIFF
--- a/apps/taormina-duel/src/app/app.component.css
+++ b/apps/taormina-duel/src/app/app.component.css
@@ -1,0 +1,1 @@
+/* stylelint-disable no-empty-source */


### PR DESCRIPTION
### Description
Add not empty app css file.

Missing app css file was breaking production build.
Empty css file is throwing a style lint error.

